### PR TITLE
POC for receiving GitHub webhooks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,6 +3,18 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/google/go-github"
+  packages = ["github"]
+  revision = "fbfee053c26dab3772adfc7799d995eed379133e"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/google/go-querystring"
+  packages = ["query"]
+  revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
+
+[[projects]]
+  branch = "master"
   name = "github.com/sergi/go-diff"
   packages = ["diffmatchpatch"]
   revision = "1744e2970ca51c86172c8190fadad617561ed6e7"
@@ -34,6 +46,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "55cf4b982d50b46d71cbdd056087fbb67caafd1f4451330ceae9fd82b7c5b52d"
+  inputs-digest = "99c0c7e5d9e98775e06fc344339939d12dd34af90e84ba7f97c6663d1beb4d99"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,3 +1,7 @@
 [[constraint]]
   name = "gopkg.in/src-d/go-git.v4"
   version = "4.0.0-rc15"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/google/go-github"

--- a/poc/webhooks/main.go
+++ b/poc/webhooks/main.go
@@ -1,0 +1,97 @@
+// Proof-of-concept Github Webhook receiver for receiving POST requests from
+// Github and determining the event, branch, and repository from the request
+// payload.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/google/go-github/github"
+)
+
+var secret = ""
+
+// Arguments: [port] [secret]
+// Secret is the secret key used to secure the HTTP POST payload. You enter this
+// secret when you're setting up your Github Webhook.
+func main() {
+	// Process CLI args
+	if len(os.Args) != 3 {
+		log.Println("Usage: webhooks [port] [secret]")
+		return
+	}
+
+	port, err := strconv.ParseInt(os.Args[1], 10, 32)
+	if err != nil {
+		log.Println(fmt.Sprintf("Invalid port: %s", err))
+		return
+	}
+	secret = os.Args[2]
+
+	log.Println(fmt.Sprintf("Starting POC Webhook Receiver on port %v", port))
+
+	// Route all requests to the requestHandler.
+	http.HandleFunc("/", requestHandler)
+
+	// Listen on port 8081. Pass nil as handler so TCP connections are handled
+	// by the DefaultServeMux.
+	err = http.ListenAndServe(fmt.Sprintf(":%v", port), nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// requestHandler writes a response to a request into the given ResponseWriter.
+func requestHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "I'm a little Webhook, short and stout!")
+
+	payload, err := github.ValidatePayload(r, []byte(secret))
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	event, err := github.ParseWebHook(github.WebHookType(r), payload)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	switch event := event.(type) {
+	case *github.PushEvent:
+		processPushEvent(event)
+	case *github.PullRequestEvent:
+		processPullRequestEvent(event)
+	default:
+		log.Println("Unrecognized event type")
+	}
+}
+
+// processPushEvent prints information about the given PushEvent.
+func processPushEvent(event *github.PushEvent) {
+	repo := event.GetRepo()
+	log.Println("Received PushEvent")
+	log.Println(fmt.Sprintf("Repository Name: %s", *repo.Name))
+	log.Println(fmt.Sprintf("Repository Git URL: %s", *repo.GitURL))
+	log.Println(fmt.Sprintf("Ref: %s", event.GetRef()))
+}
+
+// processPullREquestEvent prints information about the given PullRequestEvent.
+// Handling PRs is unnecessary because merging one will trigger a PushEvent.
+func processPullRequestEvent(event *github.PullRequestEvent) {
+	repo := event.GetRepo()
+	pr := event.GetPullRequest()
+	merged := "false"
+	if *pr.Merged {
+		merged = "true"
+	}
+	log.Println("Received PullRequestEvent")
+	log.Println(fmt.Sprintf("Repository Name: %s", *repo.Name))
+	log.Println(fmt.Sprintf("Repository Git URL: %s", *repo.GitURL))
+	log.Println(fmt.Sprintf("Ref: %s", pr.GetBase().GetRef()))
+	log.Println(fmt.Sprintf("Merge status: %v", merged))
+}


### PR DESCRIPTION
:hourglass: **Status**: Ready for review

:tickets: **Ticket(s)**: #5 

---

## :construction_worker: Changes

Created a simple HTTP server that listens on a port for requests from GitHub. When it receives a request it attempts to validate it with the given secret and print information about the GitHub event in the payload.

## :flashlight: Testing Instructions

Ask @chadlagore for SSH access to our `inertia-test` Google Cloud instance.
Set up a WebHook on a GitHub repo and point it to our GC instance on port `8081`. You can set whatever secret you want, it just can't be blank. Make sure your WebHook is set to respond to `push` events. Pull request events are optional.
Run this POC on the GC instance, providing it with port to listen on, and the secret to use as command-line arguments (`./webhooks 8081 mysupersecret`).
Push to your repo. The logs on our GC instance should show something like 
```
2017/12/09 23:22:17 Starting POC Webhook Receiver on port 8081
2017/12/09 23:32:40 Received PushEvent
2017/12/09 23:32:40 Repository Name: Personal-Website
2017/12/09 23:32:40 Repository Git URL: git://github.com/chadlagore/low-quality-code.git
2017/12/09 23:32:40 Ref: refs/heads/webhook-test
```
