### PR TITLE
Add repo to post request

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The output of `inertia bootstrap [REMOTE]` has given you two important pieces of
 After adding these pieces of information to your GitHub settings,
 
 ```bash
-$> inertia deploy glcoud
+$> inertia deploy [REMOTE] up
 ```
 
 ## Development


### PR DESCRIPTION
:hourglass: **Status**: WIP

:tickets: **Ticket(s)**: #42

---

## :construction_worker: Changes

+ Added the repo name to the `/up` request
+ We punted on this because it might show up via webhook when you add the deploy key - maybe not - easy enough to add it here.
+ SUPER ALPHA. Only knows `origin` :joy: just use this branch for testing.

## :flashlight: Testing Instructions

