### PR TITLE
Hotfix the config writer; unexport initialization functions

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -75,7 +75,7 @@ Requires:
 Run 'inertia remote bootstrap [REMOTE]' to collect these.`,
 	Args: cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		config, err := GetProjectConfigFromDisk()
+		config, err := getProjectConfigFromDisk()
 		if err != nil {
 			log.WithError(err)
 		}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -9,15 +9,16 @@ import (
 )
 
 func TestConfigWrite(t *testing.T) {
+	var writer bytes.Buffer
 	config := &Config{
 		CurrentRemoteName: "test",
 		CurrentRemoteVPS:  getTestRemote(),
+		Writer:            &writer,
 	}
 	inertiaJSON, err := json.Marshal(config)
 	assert.Nil(t, err)
 
-	var f bytes.Buffer
-	n, err := config.Write(&f)
+	n, err := config.Write()
 
 	assert.Nil(t, err)
 	assert.Equal(t, n, len(inertiaJSON))

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -78,9 +78,9 @@ inerta remote bootstrap gcloud
 inerta remote status gcloud`,
 	Run: func(cmd *cobra.Command, args []string) {
 		verbose, _ := cmd.Flags().GetBool("verbose")
-		config, err := GetProjectConfigFromDisk()
+		config, err := getProjectConfigFromDisk()
 		if err != nil {
-			log.WithError(err)
+			log.Fatal(err)
 		}
 		if config.CurrentRemoteName == noInertiaRemote {
 			println("No remote currently set.")
@@ -103,7 +103,7 @@ file. Specify a VPS name and an IP address.`,
 	Args: cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure project initialized.
-		_, err := GetProjectConfigFromDisk()
+		_, err := getProjectConfigFromDisk()
 		if err != nil {
 			log.WithError(err)
 		}
@@ -125,7 +125,7 @@ for updates to this repository's remote master branch.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure project initialized.
-		config, err := GetProjectConfigFromDisk()
+		config, err := getProjectConfigFromDisk()
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -153,7 +153,7 @@ var statusCmd = &cobra.Command{
 behaviour, and other information.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		config, err := GetProjectConfigFromDisk()
+		config, err := getProjectConfigFromDisk()
 		if err != nil {
 			log.WithError(err)
 		}
@@ -249,9 +249,7 @@ func (remote *RemoteVPS) Bootstrap(runner SSHSession, name string, config *Confi
 	}
 
 	config.DaemonAPIToken = token
-	f, err := GetConfigFile()
-	defer f.Close()
-	_, err = config.Write(f)
+	_, err = config.Write()
 	if err != nil {
 		return err
 	}
@@ -320,7 +318,7 @@ func (remote *RemoteVPS) DaemonUp(session SSHSession, daemonPort string) error {
 	daemonCmdStr := fmt.Sprintf(string(daemonCmd), daemonPort)
 	_, stderr, err := remote.RunSSHCommand(session, daemonCmdStr)
 	if err != nil {
-		println(stderr)
+		println(stderr.String())
 		return err
 	}
 
@@ -375,7 +373,7 @@ func (remote *RemoteVPS) GetDaemonAPIToken(session SSHSession) (string, error) {
 
 	stdout, stderr, err := remote.RunSSHCommand(session, string(daemonCmd))
 	if err != nil {
-		log.Println(stderr)
+		log.Println(stderr.String())
 		return "", err
 	}
 
@@ -386,7 +384,7 @@ func (remote *RemoteVPS) GetDaemonAPIToken(session SSHSession) (string, error) {
 // addNewRemote adds a new remote to the project config file.
 func addNewRemote(name, IP, user, pemLoc, port string) error {
 	// Just wipe configuration for MVP.
-	config, err := GetProjectConfigFromDisk()
+	config, err := getProjectConfigFromDisk()
 	if err != nil {
 		return err
 	}
@@ -399,9 +397,7 @@ func addNewRemote(name, IP, user, pemLoc, port string) error {
 		Port: port,
 	}
 
-	f, err := GetConfigFile()
-	defer f.Close()
-	_, err = config.Write(f)
+	_, err = config.Write()
 	if err != nil {
 		return err
 	}

--- a/cmd/remote_test.go
+++ b/cmd/remote_test.go
@@ -55,7 +55,6 @@ func TestDaemonDown(t *testing.T) {
 	remote := getTestRemote()
 	script, err := ioutil.ReadFile("bootstrap/daemon-up.sh")
 	assert.Nil(t, err)
-
 	actualCommand := fmt.Sprintf(string(script), "8081")
 
 	// Make sure the right command is run.
@@ -69,31 +68,30 @@ func TestDaemonDown(t *testing.T) {
 
 func TestKeyGen(t *testing.T) {
 	remote := getTestRemote()
-	script, err := ioutil.ReadFile("bootstrap/daemon-down.sh")
+	script, err := ioutil.ReadFile("bootstrap/token.sh")
 	assert.Nil(t, err)
 
 	// Make sure the right command is run.
 	session := mockSSHRunner{r: remote}
 
 	// Make sure the right command is run.
-	err = remote.DaemonDown(&session)
+	_, err = remote.GetDaemonAPIToken(&session)
 	assert.Nil(t, err)
 	assert.Equal(t, session.LastCall, string(script))
 }
 
-/*
 func TestBootstrap(t *testing.T) {
 	remote := getTestRemote()
 	script, err := ioutil.ReadFile("bootstrap/token.sh")
 	assert.Nil(t, err)
 
 	// Make sure the right command is run.
+	var writer bytes.Buffer
 	session := mockSSHRunner{r: remote}
-	err = remote.Bootstrap(&session, "gcloud", &Config{})
+	err = remote.Bootstrap(&session, "gcloud", &Config{Writer: &writer})
 	assert.Nil(t, err)
 
 	// Just check last call.
 	assert.Nil(t, err)
 	assert.Equal(t, session.LastCall, string(script))
 }
-*/

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -158,7 +158,7 @@ func getAPIPrivateKey(*jwt.Token) (interface{}, error) {
 // requests sent to the daemon from local config. For now, we simply use the GitHub
 // deploy key.
 func getAPIPrivateKeyFromConfig() (string, error) {
-	cfg, err := GetProjectConfigFromDisk()
+	cfg, err := getProjectConfigFromDisk()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
:hourglass: **Status**: Ready For Review

:tickets: **Ticket(s)**: None

---

## :construction_worker: Changes

+ Fixed the config writer so that we can still mock `remote.Bootstrap` appropriately (it writes to disk in the middle of the call.
+ Added a new field to `Config`:

```go
// Config represents the current projects configuration.
type Config struct {
	CurrentRemoteName string     `json:"name"`
	CurrentRemoteVPS  *RemoteVPS `json:"remote"`
	DaemonAPIToken    string     `json:"token"`
	io.Writer         `json:"-"`
}
```

The `io.Writer` is used in the call `config.Write()`. It holds some file or buffer to write the configuration to (useful for testing).

+ Unexported some functions as well (sorry for the noise).

## :flashlight: Testing Instructions

```go
go test ./cmd -cover
```
