### PR TITLE
'inertia remote add' walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ $> inertia init
 
 $> inertia remote add glcoud 35.227.171.49 -u root -i /path/to/my/.ssh/id_rsa
 Remote 'glcoud' added.
+$> inertia remote add gcloud
+Enter location of PEM file (leave blank to use '/Users/yourspecialname/.ssh/id_rsa'):
+/path/to/my/.ssh/id_rsa
+Enter IP address of remote:
+35.227.171.49
+Enter user:
+root
+Remote 'gcloud' added.
+You can now run 'inertia gcloud init' to set this remote
+up for continuous deployment.
 
 $> inertia gcloud init
 Bootstrapping remote

--- a/README.md
+++ b/README.md
@@ -20,18 +20,19 @@ Inside of a git repository, run the following:
 ```bash
 $> inertia init
 
-$> inertia remote add glcoud 35.227.171.49 -u root -i /path/to/my/.ssh/id_rsa
-Remote 'glcoud' added.
 $> inertia remote add gcloud
 Enter location of PEM file (leave blank to use '/Users/yourspecialname/.ssh/id_rsa'):
 /path/to/my/.ssh/id_rsa
-Enter IP address of remote:
-35.227.171.49
 Enter user:
 root
-Remote 'gcloud' added.
-You can now run 'inertia gcloud init' to set this remote
-up for continuous deployment.
+Enter IP address of remote:
+35.227.171.49
+Port 8081 will be used as the daemon port.
+Run this 'inertia remote add' with the -p flag to set a custom port.
+
+Remote 'gcloud' has been added!
+You can now run 'inertia gcloud init' to set this remote up
+for continuous deployment.
 
 $> inertia gcloud init
 Bootstrapping remote

--- a/client/remote.go
+++ b/client/remote.go
@@ -255,10 +255,6 @@ func AddNewRemote(name, IP, user, pemLoc, port string) error {
 		return err
 	}
 
-	println("Remote '" + name + "' added.")
-	println("You can now run 'inertia " + name + " init' to set this remote")
-	println("up for continuous deployment.")
-
 	return nil
 }
 

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -82,31 +82,37 @@ file. Specify a VPS name.`,
 		defaultSSHLoc := filepath.Join(sshDir, "id_rsa")
 
 		var response string
-		fmt.Println("Enter location of PEM file (leave blank to use '" + defaultSSHLoc + "'): ")
+		fmt.Println("Enter location of PEM file (leave blank to use '" + defaultSSHLoc + "'):")
 		_, err = fmt.Scanln(&response)
 		if err != nil {
 			response = defaultSSHLoc
 		}
 		pemLoc := response
 
-		fmt.Printf("Enter IP address of remote: \n")
-		_, err = fmt.Scanln(&response)
-		if err != nil {
-			log.Fatal("That is not a valid IP address - please try again.")
-		}
-		address := response
-
-		fmt.Printf("Enter user: \n")
+		fmt.Println("Enter user:")
 		_, err = fmt.Scanln(&response)
 		if err != nil {
 			log.Fatal("That is not a valid user - please try again.")
 		}
 		user := response
 
+		fmt.Println("Enter IP address of remote:")
+		_, err = fmt.Scanln(&response)
+		if err != nil {
+			log.Fatal("That is not a valid IP address - please try again.")
+		}
+		address := response
+		fmt.Println("Port " + port + " will be used as the daemon port.")
+		fmt.Println("Run this 'inertia remote add' with the -p flag to set a custom port.")
+
 		err = client.AddNewRemote(args[0], address, user, pemLoc, port)
 		if err != nil {
 			log.WithError(err)
 		}
+
+		fmt.Println("\nRemote '" + args[0] + "' has been added!")
+		fmt.Println("You can now run 'inertia " + args[0] + " init' to set this remote up")
+		fmt.Println("for continuous deployment.")
 	},
 }
 

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -66,18 +66,40 @@ var addCmd = &cobra.Command{
 	Short: "Add a reference to a remote VPS instance",
 	Long: `Add a reference to a remote VPS instance. Requires 
 information about the VPS including IP address, user and a PEM
-file. Specify a VPS name and an IP address.`,
-	Args: cobra.MinimumNArgs(2),
+file. Specify a VPS name.`,
+	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure project initialized.
 		_, err := client.GetProjectConfigFromDisk()
 		if err != nil {
 			log.WithError(err)
 		}
-		user, _ := cmd.Flags().GetString("user")
-		pemLoc, _ := cmd.Flags().GetString("identity")
+
 		port, _ := cmd.Flags().GetString("port")
-		err = client.AddNewRemote(args[0], args[1], user, pemLoc, port)
+
+		var response string
+		fmt.Printf("Enter location of PEM file: ")
+		_, err = fmt.Scanln(&response)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pemLoc := response
+
+		fmt.Printf("Enter IP address of remote: ")
+		_, err = fmt.Scanln(&response)
+		if err != nil {
+			log.Fatal(err)
+		}
+		address := response
+
+		fmt.Printf("Enter user: ")
+		_, err = fmt.Scanln(&response)
+		if err != nil {
+			log.Fatal(err)
+		}
+		user := response
+
+		err = client.AddNewRemote(args[0], address, user, pemLoc, port)
 		if err != nil {
 			log.WithError(err)
 		}

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -40,7 +40,7 @@ of the VPS. Must run 'inertia init' in your repository before using.
 
 Example:
 
-inerta remote add gcloud 35.123.55.12 -i /Users/path/to/pem
+inerta remote add gcloud
 inerta remote bootstrap gcloud
 inerta remote status gcloud`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -62,7 +62,7 @@ inerta remote status gcloud`,
 
 // addCmd represents the remote add command
 var addCmd = &cobra.Command{
-	Use:   "add",
+	Use:   "add [REMOTE]",
 	Short: "Add a reference to a remote VPS instance",
 	Long: `Add a reference to a remote VPS instance. Requires 
 information about the VPS including IP address, user and a PEM
@@ -77,25 +77,29 @@ file. Specify a VPS name.`,
 
 		port, _ := cmd.Flags().GetString("port")
 
+		homeEnvVar := os.Getenv("HOME")
+		sshDir := filepath.Join(homeEnvVar, ".ssh")
+		defaultSSHLoc := filepath.Join(sshDir, "id_rsa")
+
 		var response string
-		fmt.Printf("Enter location of PEM file: ")
+		fmt.Println("Enter location of PEM file (leave blank to use '" + defaultSSHLoc + "'): ")
 		_, err = fmt.Scanln(&response)
 		if err != nil {
-			log.Fatal(err)
+			response = defaultSSHLoc
 		}
 		pemLoc := response
 
-		fmt.Printf("Enter IP address of remote: ")
+		fmt.Printf("Enter IP address of remote: \n")
 		_, err = fmt.Scanln(&response)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal("That is not a valid IP address - please try again.")
 		}
 		address := response
 
-		fmt.Printf("Enter user: ")
+		fmt.Printf("Enter user: \n")
 		_, err = fmt.Scanln(&response)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal("That is not a valid user - please try again.")
 		}
 		user := response
 
@@ -185,10 +189,6 @@ func init() {
 	remoteCmd.AddCommand(addCmd)
 	remoteCmd.AddCommand(statusCmd)
 
-	homeEnvVar := os.Getenv("HOME")
-	sshDir := filepath.Join(homeEnvVar, ".ssh")
-	defaultSSHLoc := filepath.Join(sshDir, "id_rsa")
-
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
@@ -198,7 +198,5 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	remoteCmd.Flags().BoolP("verbose", "v", false, "Verbose output")
-	addCmd.Flags().StringP("user", "u", "root", "User for SSH access")
-	addCmd.Flags().StringP("identity", "i", defaultSSHLoc, "PEM file location")
 	addCmd.Flags().StringP("port", "p", daemon.DefaultPort, "Daemon port")
 }


### PR DESCRIPTION
:hourglass: **Status**: redy redy

:tickets: **Ticket(s)**: Close #53 'inertia remote add' walkthrough

---

## :construction_worker: Changes

- Walkthrough for the 'remote add' command
- Left `port` as a flag... but maybe should make it part of the walkthrough? 🤔 

## :flashlight: Testing Instructions

```
go install
inertia init
inertia remote add gcloud
```
