### PR TITLE
Check for docker-compose on init

### DIFF
--- a/client/init.go
+++ b/client/init.go
@@ -51,6 +51,10 @@ func InitializeInertiaProject() error {
 	if err != nil {
 		return err
 	}
+	err = common.CheckForDockerCompose(cwd)
+	if err != nil {
+		return err
+	}
 
 	return createConfigDirectory()
 }

--- a/common/util.go
+++ b/common/util.go
@@ -55,6 +55,22 @@ func CheckForGit(cwd string) error {
 	return nil
 }
 
+// CheckForDockerCompose returns error if current directory is a
+// not a docker-compose project
+func CheckForDockerCompose(cwd string) error {
+	dockerComposeYML := filepath.Join(cwd, "docker-compose.yml")
+	dockerComposeYAML := filepath.Join(cwd, "docker-compose.yaml")
+	_, err := os.Stat(dockerComposeYML)
+	YMLpresent := os.IsNotExist(err)
+	_, err = os.Stat(dockerComposeYAML)
+	YAMLpresent := os.IsNotExist(err)
+	if YMLpresent && YAMLpresent {
+		return errors.New("this does not appear to be a docker-compose project - currently,\n" +
+			"Inertia only supports docker-compose projects.")
+	}
+	return nil
+}
+
 // GetLocalRepo gets the repo from disk.
 func GetLocalRepo() (*git.Repository, error) {
 	cwd, err := os.Getwd()

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,4 +25,24 @@ func TestGetSSHRemoteURL(t *testing.T) {
 
 	assert.Equal(t, sshURL, GetSSHRemoteURL(httpsURL))
 	assert.Equal(t, sshURL, GetSSHRemoteURL(sshURL))
+}
+
+func TestCheckForGit(t *testing.T) {
+	cwd, _ := os.Getwd()
+	assert.NotEqual(t, nil, CheckForGit(cwd))
+	inertia := strings.TrimSuffix(cwd, "/common")
+	assert.Equal(t, nil, CheckForGit(inertia))
+}
+
+func TestCheckForDockerCompose(t *testing.T) {
+	cwd, _ := os.Getwd()
+	assert.NotEqual(t, nil, CheckForDockerCompose(cwd))
+	file, _ := os.Create(cwd + "/docker-compose.yml")
+	file.Close()
+	assert.Equal(t, nil, CheckForDockerCompose(cwd))
+	os.Remove(cwd + "/docker-compose.yml")
+	file, _ = os.Create(cwd + "/docker-compose.yaml")
+	file.Close()
+	assert.Equal(t, nil, CheckForDockerCompose(cwd))
+	os.Remove(cwd + "/docker-compose.yaml")
 }


### PR DESCRIPTION
:hourglass: **Status**: ready

:tickets: **Ticket(s)**: #36 Warn if `inertia init` in non-docker-compose project

---

## :construction_worker: Changes

- Now runs a check to see if we are in a docker-compose directory when user runs `inertia init`

## :flashlight: Testing Instructions

```
go install
inertia init
```
