### PR TITLE
Properly detect existing inertia configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Inertia makes it easy to set up automated deployment for Dockerized
 applications.
 
-[![Coverage Status](https://coveralls.io/repos/github/ubclaunchpad/inertia/badge.svg?branch=master)](https://coveralls.io/github/ubclaunchpad/inertia?branch=master)
+[![Build Status](https://travis-ci.org/ubclaunchpad/inertia.svg?branch=master)](https://travis-ci.org/ubclaunchpad/inertia)[![Coverage Status](https://coveralls.io/repos/github/ubclaunchpad/inertia/badge.svg?branch=master)](https://coveralls.io/github/ubclaunchpad/inertia?branch=master)
 
 ## Installation
 

--- a/client/init.go
+++ b/client/init.go
@@ -69,10 +69,10 @@ func createConfigDirectory() error {
 	}
 
 	_, dirErr := os.Stat(configDirPath)
-	_, fileErr := os.Stat(configFilePath)
+	s, fileErr := os.Stat(configFilePath)
 
 	// Check if everything already exists.
-	if os.IsExist(dirErr) && os.IsExist(fileErr) {
+	if s != nil {
 		return errors.New("inertia already properly configured in this folder")
 	}
 


### PR DESCRIPTION
:hourglass: **Status**: ready

:tickets: **Ticket(s)**: Closes #31 

---

## :construction_worker: Changes

- Fixes minor bug where `inertia init` does not properly detect existing inertia configuration and proceeds to overwrite it causing weird things to happen

## :flashlight: Testing Instructions

```
go install
inertia init
inertia init
```
