### PR TITLE
Deployment Logs

### DIFF
--- a/client/deploy.go
+++ b/client/deploy.go
@@ -38,6 +38,7 @@ type DaemonRequester interface {
 	Down() (*http.Response, error)
 	Status() (*http.Response, error)
 	Reset() (*http.Response, error)
+	Logs(bool, string) (*http.Response, error)
 }
 
 // GetDeployment returns the local deployment setup
@@ -74,7 +75,7 @@ func (d *Deployment) Up(stream bool) (*http.Response, error) {
 		return nil, err
 	}
 
-	reqContent := common.UpRequest{
+	reqContent := common.DaemonRequest{
 		Stream: stream,
 		Repo:   common.GetSSHRemoteURL(origin.Config().URLs[0]),
 	}
@@ -146,5 +147,31 @@ func (d *Deployment) Reset() (*http.Response, error) {
 		return nil, errors.New("Error when reseting project on deployment")
 	}
 
+	return resp, nil
+}
+
+// Logs get logs
+func (d *Deployment) Logs(stream bool, container string) (*http.Response, error) {
+	host := "http://" + d.RemoteVPS.GetIPAndPort() + "/logs"
+
+	reqContent := common.DaemonRequest{
+		Stream:    stream,
+		Container: container,
+	}
+	body, err := json.Marshal(reqContent)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", host, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+d.Auth)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.New("Error when deploying project: " + err.Error())
+	}
 	return resp, nil
 }

--- a/client/deploy_test.go
+++ b/client/deploy_test.go
@@ -59,7 +59,7 @@ func TestUp(t *testing.T) {
 		body, err := ioutil.ReadAll(req.Body)
 		assert.Nil(t, err)
 		defer req.Body.Close()
-		var upReq common.UpRequest
+		var upReq common.DaemonRequest
 		err = json.Unmarshal(body, &upReq)
 		assert.Nil(t, err)
 		assert.Equal(t, "www.myremote.com", upReq.Repo)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -192,8 +192,11 @@ var deployResetCmd = &cobra.Command{
 
 var deployLogsCmd = &cobra.Command{
 	Use:   "logs",
-	Short: "",
-	Long:  ``,
+	Short: "Access logs of your VPS",
+	Long: `Access logs of containers of your VPS. Argument 'docker-compose'
+	will retrieve logs of the docker-compose build. The additional argument can 
+	also be used to access logs of specific containers - use  'inertia [REMOTE] 
+	status' to see what containers are accessible.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Start the deployment
 		deployment, err := client.GetDeployment()
@@ -223,7 +226,7 @@ var deployLogsCmd = &cobra.Command{
 			}
 			switch resp.StatusCode {
 			case http.StatusOK:
-				fmt.Printf("(Status code %d) Project build started!\n", resp.StatusCode)
+				fmt.Printf("(Status code %d) Logs: \n%s\n", resp.StatusCode, body)
 			case http.StatusForbidden:
 				fmt.Printf("(Status code %d) Bad auth:\n%s\n", resp.StatusCode, body)
 			case http.StatusPreconditionFailed:

--- a/common/types.go
+++ b/common/types.go
@@ -22,8 +22,9 @@ const (
 	DaemonOkResp = "I'm a little Webhook, short and stout!"
 )
 
-// UpRequest is the body of a up request to the daemon.
-type UpRequest struct {
-	Stream bool   `json:"stream"`
-	Repo   string `json:"repo"`
+// DaemonRequest is the configurable body of a request to the daemon.
+type DaemonRequest struct {
+	Stream    bool   `json:"stream"`
+	Repo      string `json:"repo,omitempty"`
+	Container string `json:"container,omitempty"`
 }

--- a/common/util.go
+++ b/common/util.go
@@ -184,7 +184,7 @@ func CompareRemotes(localRepo *git.Repository, remoteURL string) error {
 
 // FlushOutput continuously writes everything in given PipeReader
 // to a ResponseWriter. Use this as a goroutine.
-func FlushOutput(w io.Writer, pipeReader *io.PipeReader) {
+func FlushOutput(w io.Writer, pipeReader io.ReadCloser) {
 	buffer := make([]byte, 100)
 	for {
 		// Read from pipe then write to ResponseWriter and flush it,

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -2,10 +2,8 @@ package common
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -62,10 +60,10 @@ func TestCheckForDockerCompose(t *testing.T) {
 	os.Remove(cwd + "/docker-compose.yaml")
 }
 
-func TestFlushOutput(t *testing.T) {
+func TestFlushRoutine(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		reader, writer := io.Pipe()
-		go FlushOutput(w, reader)
+		go FlushRoutine(w, reader)
 
 		fmt.Println(writer, "Hello!")
 		time.Sleep(time.Millisecond)
@@ -100,31 +98,4 @@ func TestFlushOutput(t *testing.T) {
 
 		i++
 	}
-}
-
-func TestPipeErr(t *testing.T) {
-	var b bytes.Buffer
-	w := httptest.NewRecorder()
-	PipeErr(&b, "Wee!", 200)
-	PipeErr(w, "Wee!", 200)
-	assert.Equal(t, "[ERROR 200] Wee!", b.String())
-
-	body, err := ioutil.ReadAll(w.Body)
-	assert.Nil(t, err)
-	assert.Equal(t, "Wee!\n", string(body))
-	assert.Equal(t, 200, w.Code)
-}
-
-func TestPipeSuccess(t *testing.T) {
-	var b bytes.Buffer
-	w := httptest.NewRecorder()
-	PipeSuccess(&b, "Wee!", 200)
-	PipeSuccess(w, "Wee!", 200)
-	assert.Equal(t, "Wee!\n", b.String())
-
-	body, err := ioutil.ReadAll(w.Body)
-	assert.Nil(t, err)
-	assert.Equal(t, "Wee!\n", string(body))
-	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, "text/html", w.Header().Get("Content-Type"))
 }

--- a/daemon/docker.go
+++ b/daemon/docker.go
@@ -102,7 +102,7 @@ func deploy(repo *git.Repository, cli *docker.Client, out io.Writer) error {
 		ctx, &container.Config{
 			Image:      dockerCompose,
 			WorkingDir: "/build/project",
-			Env:        []string{"HOME:/build"},
+			Env:        []string{"HOME=/build"},
 			Cmd:        []string{"up", "--build"},
 		},
 		&container.HostConfig{
@@ -180,6 +180,8 @@ func killActiveContainers(cli *docker.Client) error {
 	if err != nil {
 		return err
 	}
-	log.Println("Removed " + strings.Join(report.ContainersDeleted, ", "))
+	if len(report.ContainersDeleted) > 0 {
+		log.Println("Removed " + strings.Join(report.ContainersDeleted, ", "))
+	}
 	return nil
 }

--- a/daemon/docker.go
+++ b/daemon/docker.go
@@ -102,8 +102,11 @@ func deploy(repo *git.Repository, cli *docker.Client, out io.Writer) error {
 		ctx, &container.Config{
 			Image:      dockerCompose,
 			WorkingDir: "/build/project",
-			Env:        []string{"HOME=/build"},
-			Cmd:        []string{"up", "--build"},
+			Cmd: []string{
+				"up",
+				"--build",
+				"-e HOME=/build",
+			},
 		},
 		&container.HostConfig{
 			Binds: []string{

--- a/daemon/docker.go
+++ b/daemon/docker.go
@@ -28,7 +28,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	docker "github.com/docker/docker/client"
-	log "github.com/sirupsen/logrus"
 	"github.com/ubclaunchpad/inertia/common"
 	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
@@ -77,7 +76,7 @@ func deploy(repo *git.Repository, cli *docker.Client, out io.Writer) error {
 
 	// Kill active project containers if there are any
 	fmt.Fprintln(out, "Shutting down active containers...")
-	err = killActiveContainers(cli)
+	err = killActiveContainers(cli, out)
 	if err != nil {
 		return err
 	}
@@ -132,9 +131,9 @@ func deploy(repo *git.Repository, cli *docker.Client, out io.Writer) error {
 	time.Sleep(3 * time.Second)
 	_, err = getActiveContainers(cli)
 	if err != nil {
-		killErr := killActiveContainers(cli)
+		killErr := killActiveContainers(cli, out)
 		if killErr != nil {
-			log.WithError(err)
+			fmt.Fprintln(out, err)
 		}
 		return errors.New("Docker-compose failed: " + err.Error())
 	}
@@ -162,7 +161,7 @@ func getActiveContainers(cli *docker.Client) ([]types.Container, error) {
 }
 
 // killActiveContainers kills all active project containers (ie not including daemon)
-func killActiveContainers(cli *docker.Client) error {
+func killActiveContainers(cli *docker.Client, out io.Writer) error {
 	ctx := context.Background()
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
 	if err != nil {
@@ -171,7 +170,7 @@ func killActiveContainers(cli *docker.Client) error {
 
 	for _, container := range containers {
 		if container.Names[0] != "/inertia-daemon" {
-			log.Println("Killing " + container.Image + " (" + container.Names[0] + ")...")
+			fmt.Fprintln(out, "Killing "+container.Image+" ("+container.Names[0]+")...")
 			err := cli.ContainerKill(ctx, container.ID, "SIGKILL")
 			if err != nil {
 				return err
@@ -184,7 +183,7 @@ func killActiveContainers(cli *docker.Client) error {
 		return err
 	}
 	if len(report.ContainersDeleted) > 0 {
-		log.Println("Removed " + strings.Join(report.ContainersDeleted, ", "))
+		fmt.Fprintln(out, "Removed "+strings.Join(report.ContainersDeleted, ", "))
 	}
 	return nil
 }

--- a/daemon/handler.go
+++ b/daemon/handler.go
@@ -212,9 +212,7 @@ func upHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/html")
-	w.WriteHeader(http.StatusCreated)
-	fmt.Fprintln(w, "Project build started!")
+	common.PipeSuccess(writer, "Project build started!", http.StatusCreated)
 }
 
 // downHandler tries to take the deployment offline

--- a/daemon/logger.go
+++ b/daemon/logger.go
@@ -68,7 +68,7 @@ func (l *daemonLogger) Println(a interface{}) {
 
 // Err directs message and status to http.Error when appropriate
 func (l *daemonLogger) Err(msg string, status int) {
-	fmt.Fprintf(l.writer, "[ERROR %s] %s", strconv.Itoa(status), msg)
+	fmt.Fprintf(l.writer, "[ERROR %s] %s\n", strconv.Itoa(status), msg)
 	if !l.stream {
 		http.Error(l.httpWriter, msg, status)
 	}
@@ -76,7 +76,7 @@ func (l *daemonLogger) Err(msg string, status int) {
 
 // Success directs status to Header and sets content type when appropriate
 func (l *daemonLogger) Success(msg string, status int) {
-	fmt.Fprintf(l.writer, "[SUCCESS %s] %s", strconv.Itoa(status), msg)
+	fmt.Fprintf(l.writer, "[SUCCESS %s] %s\n", strconv.Itoa(status), msg)
 	if !l.stream {
 		l.httpWriter.Header().Set("Content-Type", "text/html")
 		l.httpWriter.WriteHeader(status)
@@ -92,7 +92,6 @@ func (l *daemonLogger) GetWriter() io.Writer {
 // Close shuts down the logger
 func (l *daemonLogger) Close() {
 	if l.stream {
-		common.Flush(l.httpWriter, l.reader, make([]byte, 100))
 		l.reader.Close()
 	}
 }

--- a/daemon/logger.go
+++ b/daemon/logger.go
@@ -1,0 +1,99 @@
+package daemon
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/ubclaunchpad/inertia/common"
+)
+
+// daemonWriter is a custom implementation of io.Writer that
+// writes to both os.Stdout and a stream writer if appropriate.
+type daemonWriter struct {
+	strWriter io.Writer
+	stdWriter io.Writer
+}
+
+func (d *daemonWriter) Write(p []byte) (n int, err error) {
+	if d.strWriter != nil {
+		d.strWriter.Write(p)
+	}
+	return d.stdWriter.Write(p)
+}
+
+// logger is a multilogger used by the daemon to pipe
+// output to multiple places depending on context.
+type logger interface {
+	Println(a interface{})
+	Err(msg string, status int)
+	Success(msg string, status int)
+	GetWriter() io.Writer
+	Close()
+}
+
+// daemonLogger is the default logger implementation used
+// by the Inertia daemon
+type daemonLogger struct {
+	stream     bool
+	stop       chan struct{}
+	writer     io.Writer
+	reader     *io.PipeReader
+	httpWriter http.ResponseWriter
+}
+
+// newLogger creates a new logger
+func newLogger(stream bool, httpWriter http.ResponseWriter) logger {
+	writer := &daemonWriter{stdWriter: os.Stdout}
+	var reader *io.PipeReader
+	if stream {
+		r, w := io.Pipe()
+		go common.FlushRoutine(httpWriter, r)
+		writer.strWriter = w
+		reader = r
+	}
+	return &daemonLogger{
+		stream:     stream,
+		writer:     writer,
+		reader:     reader,
+		httpWriter: httpWriter,
+	}
+}
+
+// Println prints to logger's standard writer
+func (l *daemonLogger) Println(a interface{}) {
+	fmt.Fprintln(l.writer, a)
+}
+
+// Err directs message and status to http.Error when appropriate
+func (l *daemonLogger) Err(msg string, status int) {
+	fmt.Fprintf(l.writer, "[ERROR %s] %s", strconv.Itoa(status), msg)
+	if !l.stream {
+		http.Error(l.httpWriter, msg, status)
+	}
+}
+
+// Success directs status to Header and sets content type when appropriate
+func (l *daemonLogger) Success(msg string, status int) {
+	fmt.Fprintf(l.writer, "[SUCCESS %s] %s", strconv.Itoa(status), msg)
+	if !l.stream {
+		l.httpWriter.Header().Set("Content-Type", "text/html")
+		l.httpWriter.WriteHeader(status)
+		fmt.Fprintln(l.httpWriter, msg)
+	}
+}
+
+// GetWriter retrieves the logger's stream writer.
+func (l *daemonLogger) GetWriter() io.Writer {
+	return l.writer
+}
+
+// Close shuts down the logger
+func (l *daemonLogger) Close() {
+	if l.stream {
+		common.Flush(l.httpWriter, l.reader, make([]byte, 100))
+		l.reader.Close()
+	}
+}

--- a/daemon/logger.go
+++ b/daemon/logger.go
@@ -38,7 +38,6 @@ type logger interface {
 // by the Inertia daemon
 type daemonLogger struct {
 	stream     bool
-	stop       chan struct{}
 	writer     io.Writer
 	reader     *io.PipeReader
 	httpWriter http.ResponseWriter

--- a/daemon/logger_test.go
+++ b/daemon/logger_test.go
@@ -46,7 +46,7 @@ func TestErr(t *testing.T) {
 		httpWriter: w,
 	}
 	logger.Err("Wee!", 200)
-	assert.Equal(t, "[ERROR 200] Wee!", b.String())
+	assert.Equal(t, "[ERROR 200] Wee!\n", b.String())
 
 	// Test direct to httpResponse
 	logger.stream = false
@@ -68,7 +68,7 @@ func TestSuccess(t *testing.T) {
 		httpWriter: w,
 	}
 	logger.Success("Wee!", 200)
-	assert.Equal(t, "[SUCCESS 200] Wee!", b.String())
+	assert.Equal(t, "[SUCCESS 200] Wee!\n", b.String())
 
 	// Test direct to httpResponse
 	logger.stream = false

--- a/daemon/logger_test.go
+++ b/daemon/logger_test.go
@@ -1,0 +1,81 @@
+package daemon
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDaemonWriter(t *testing.T) {
+	var b1 bytes.Buffer
+	var b2 bytes.Buffer
+	writer := daemonWriter{
+		strWriter: &b1,
+		stdWriter: &b2,
+	}
+	writer.Write([]byte("whoah!"))
+	assert.Equal(t, "whoah!", b1.String())
+	assert.Equal(t, "whoah!", b2.String())
+}
+
+func TestNewLogger(t *testing.T) {
+	w := httptest.NewRecorder()
+	logger := newLogger(true, w)
+	_, ok := logger.GetWriter().(*daemonWriter)
+	assert.True(t, ok)
+}
+
+func TestPrintln(t *testing.T) {
+	var b bytes.Buffer
+	logger := &daemonLogger{writer: &b}
+	logger.Println("what???")
+	assert.Equal(t, "what???\n", b.String())
+}
+
+func TestErr(t *testing.T) {
+	var b bytes.Buffer
+	w := httptest.NewRecorder()
+
+	// Test streaming
+	logger := &daemonLogger{
+		stream:     true,
+		writer:     &b,
+		httpWriter: w,
+	}
+	logger.Err("Wee!", 200)
+	assert.Equal(t, "[ERROR 200] Wee!", b.String())
+
+	// Test direct to httpResponse
+	logger.stream = false
+	logger.Err("Wee!", 200)
+	body, err := ioutil.ReadAll(w.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, "Wee!\n", string(body))
+	assert.Equal(t, 200, w.Code)
+}
+
+func TestSuccess(t *testing.T) {
+	var b bytes.Buffer
+	w := httptest.NewRecorder()
+
+	// Test streaming
+	logger := &daemonLogger{
+		stream:     true,
+		writer:     &b,
+		httpWriter: w,
+	}
+	logger.Success("Wee!", 200)
+	assert.Equal(t, "[SUCCESS 200] Wee!", b.String())
+
+	// Test direct to httpResponse
+	logger.stream = false
+	logger.Success("Wee!", 200)
+	body, err := ioutil.ReadAll(w.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, "Wee!\n", string(body))
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "text/html", w.Header().Get("Content-Type"))
+}


### PR DESCRIPTION
:hourglass: **Status**: Ready

:tickets: **Ticket(s)**: Closes #37

---

## :construction_worker: Changes

- Stream Inertia daemon logs with `inertia local logs --stream`, or access most recent logs with `inertia local logs`
- Stream docker-compose logs or specific containers using `inertia local logs docker-compose` or `inertia local logs mycontainer` specifically
-Reworked logging, ~~though this is bugged right now:~~

~~https://github.com/ubclaunchpad/inertia/blob/rob/%2337-deployment-logs/daemon/handler.go#L196 doesn't seem to properly return the error to the client - I think its still floating around somewhere because if I run `inertia local up` again, the line that was supposed to be returned shows up in the container logs alongside the first log from the second call~~ 
FIXED as of 754d625, turns out a `newline` is needed for the flush to trigger

## :flashlight: Testing Instructions

```bash
inertia local init
inertia local up
inertia local logs --stream # stream inertia daemon logs
inertia local logs docker-compose --stream
```
