### PR TITLE
Branch deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Misc
+.github/*
+.scripts/*
+.static/*
+Makefile
+
+# Documentation
+README.md
+
+# Repository config files
+.coveralls.yml
+.travis.yml
+
+# Docker config files
+Dockerfile
+.dockerignore

--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,6 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
-.glide/
-
 # Vendored dependencies
 vendor
 
@@ -24,4 +21,4 @@ vendor
 
 #binary
 inertia
-inertia_*
+inertia.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,13 @@ notifications:
 services:
   - docker
 
+# Test against different version of Go
 go:
   - "1.10"
   - master 
 
-# Test different VPS platforms we want to support
 env:
+  # Test against different VPS platforms we want to support
   matrix:
     - VPS_OS=ubuntu VERSION=16.04
     - VPS_OS=ubuntu VERSION=14.04
@@ -21,7 +22,8 @@ env:
     - VPS_OS=ubuntu VERSION=latest
     - VPS_OS=debian VERSION=latest
     - VPS_OS=centos VERSION=latest
-  global: # DOCKER_USER and DOCKER_KEY
+  # DOCKER_USER and DOCKER_KEY for Docker repository access
+  global:
     - secure: "Wmv2HWUKWM0S5Kh1IgX/VKhQ21Oi85LZgHZVYXqGppa3wHO5hKYOSoWnBBR3uNgHsYPi3RL7kRNDDuKWyDAWU+2hV2xjXfqfSwsH9Sj8pFn/60KcIoMJU8EkxydJks6+H4sf04Fei1zSXc2ySTIsvCUSUKDOi8ZJCqkDxV0hIK0TmXn7isDcRWnHTvpNqLarQ4LyN9Qi8qU/NR28cNHIdkZaWxT0gciNwT9ep/vrG32aaIsNB/Ikn43A38mx5B9iSmG7YtZzDYldMEyOhCDqZIxwOjA1J1nHYqeYq/RrF6JJYpprBfEjEDa73cUBy8JVZqb3ur5uL0FeBFfToNBdK/Qbj93pkOS8pQSgyxCCpACJBeSrzuolVKLxMLbfc6YoFXaEeu7oCE5T3P4hws6yP2MD1opAMnTCLUyWRWecH6PwVwgrlur6EvrEpimGOWk4TmmomvQMRVbDF1JYuY+4QD2M2tTkmts+pwpvEkBF+aOatSE1xUWYAtwsjnAjBSL7mhWSUeBT6MlTeaO1UqNb5qW2Fbz5KSYDh71T3DslWiCxad6x48/eXBAtApQ1mHbHtCrAALHz3h1Ioe7GA/7CWigakPayfMOYuavPDE7Ghrt8m9RlvTVoV5HgWHM9Ophrv+OnAb0RYDpPKU8+ejgqqI+kV9dy10SK6LAnXoM+kd0="
     - secure: "jloKHZ9QfPnER+X34GnQQ+GIf5d+ZHiC8Nu4mNVR0QiqK4EH2BnJExOpSUtkDCLZqPdzIAD3efTs/vgm0Od+GKbOGW/s83oy605OR13Bop6fDNoMWTf6fBlZ4JxfVmJSVbv6jKhx627HTC4U1aFDxRfgmN+113YLYCodQlB3F98m5ldD1xA+uuOeLp1FXCS9p9L+1/GWninyYEjrDVZz37c6kYsQJPhPvWAr3VcnnEE0vX0RmyKIOgM3/7gYf57HMlUo6Ri0cF4+WDUV+6R8RGbInZPErTSGR3qwyGwq1RbHkqFYCU4gVSEih2uo4pflKqoiXsDkrKg5FKxE3X0YG/rKnlZ3ElX4VYg3Pn4sGvXp45QW6tb4syVGXNgmIhtmYHoTvh48DDtvsbpVc7VwLv6E/dI53BvIv5/AKGDNWafsBRo0OZfr5V/XH6JLr2eWO+PXBiqhvUsP+r29iKVywKL5hjEJ+sKkm1O0ZXJPhGJNgajG5UHr1N+s61QmZGMKas2hO0p2ZjGxje/Fmdt+DiJ6UsPhEk5uLYWjcGFnbKYZlo2WUzO6bo1P5VQDXlr6mGRwIwOf8j/QidT+pz4cYdX63BMJw40OfKB87UcegZsncJpLK7hzJpcxZ//WCqmU/EPNfeIB4JRFlzRCxzMwKe7HOTmKwz2+tbO1GyWDuw8="
 
@@ -34,7 +36,7 @@ matrix:
     - env: VPS_OS=debian VERSION=latest    
     - env: VPS_OS=centos VERSION=latest
   # Don't wait for tip tests to finish. Mark the test run green if the
-  # tests pass on the stable versions of Go.
+  # tests pass on the stable versions of Go and VPS platforms.
   fast_finish: true
 
 before_install:
@@ -45,11 +47,13 @@ before_install:
   - go get -u github.com/golang/dep/cmd/dep                     # Dependency management
   - dep ensure
 
+# Log in to Docker and set up test environment
 before_script:
   - docker login -u $DOCKER_USER -p $DOCKER_KEY  
   - make docker # TODO: specific tag!
   - make testenv VPS_OS="$VPS_OS" VERSION="$VERSION" SSH_PORT=69
 
+# Run tests and various code quality checks
 script:
   - go test -v -race -cover ./...   # Run all the tests with the race detector enabled
   - go vet ./...
@@ -59,11 +63,13 @@ script:
 
 # Push Inertia Docker image tagged as "latest" on master builds
 after_success:
-  - if [ $TRAVIS_BRANCH == "master" ] ; then make docker RELEASE=latest
+  - if [ $TRAVIS_BRANCH == "master" ] ; then make docker RELEASE=latest ; fi
 
+# Push version-tagged Docker image and build platform binaries
 before_deploy:
   - bash .scripts/release.sh
 
+# Upload compiled binaries to corresponding GitHub release
 deploy:
   provider: releases
   skip_cleanup: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN go get -u github.com/golang/dep/cmd/dep
 ADD . ${INERTIA_BUILD_HOME}
 WORKDIR ${INERTIA_BUILD_HOME}
 RUN dep ensure
-RUN go build -o /bin/inertia
+RUN go build -o /bin/inertia -ldflags "-X main.Version=$(git describe --tags)"
 
 # Copy the binary into a smaller image.
 FROM alpine

--- a/client/deploy.go
+++ b/client/deploy.go
@@ -67,8 +67,10 @@ func (d *Deployment) Up(stream bool) (*http.Response, error) {
 
 	reqContent := common.DaemonRequest{
 		Stream: stream,
-		Repo:   common.GetSSHRemoteURL(origin.Config().URLs[0]),
-		Branch: d.RemoteVPS.Branch,
+		GitOptions: &common.GitOptions{
+			RemoteURL: common.GetSSHRemoteURL(origin.Config().URLs[0]),
+			Branch:    d.Branch,
+		},
 	}
 	body, err := json.Marshal(reqContent)
 	if err != nil {

--- a/client/deploy.go
+++ b/client/deploy.go
@@ -68,6 +68,7 @@ func (d *Deployment) Up(stream bool) (*http.Response, error) {
 	reqContent := common.DaemonRequest{
 		Stream: stream,
 		Repo:   common.GetSSHRemoteURL(origin.Config().URLs[0]),
+		Branch: d.RemoteVPS.Branch,
 	}
 	body, err := json.Marshal(reqContent)
 	if err != nil {

--- a/client/deploy_test.go
+++ b/client/deploy_test.go
@@ -64,7 +64,7 @@ func TestUp(t *testing.T) {
 		var upReq common.DaemonRequest
 		err = json.Unmarshal(body, &upReq)
 		assert.Nil(t, err)
-		assert.Equal(t, "www.myremote.com", upReq.Repo)
+		assert.Equal(t, "www.myremote.com", upReq.GitOptions.RemoteURL)
 
 		// Check correct endpoint called
 		endpoint := req.URL.Path

--- a/client/remote.go
+++ b/client/remote.go
@@ -17,6 +17,7 @@ type RemoteVPS struct {
 	IP     string        `toml:"IP"`
 	User   string        `toml:"user"`
 	PEM    string        `toml:"pemfile"`
+	Branch string        `toml:"branch"`
 	Daemon *DaemonConfig `toml:"daemon"`
 }
 
@@ -229,24 +230,13 @@ func (remote *RemoteVPS) GetDaemonAPIToken(session SSHSession) (string, error) {
 }
 
 // AddNewRemote adds a new remote to the project config file.
-func AddNewRemote(name, IP, sshPort, user, pemLoc, port string) error {
-	// Just wipe configuration for MVP.
+func AddNewRemote(remote *RemoteVPS) error {
 	config, err := GetProjectConfigFromDisk()
 	if err != nil {
 		return err
 	}
 
-	config.AddRemote(&RemoteVPS{
-		Name: name,
-		IP:   IP,
-		User: user,
-		PEM:  pemLoc,
-		Daemon: &DaemonConfig{
-			Port:    port,
-			SSHPort: sshPort,
-		},
-	})
-
+	config.AddRemote(remote)
 	return config.Write()
 }
 

--- a/common/types.go
+++ b/common/types.go
@@ -6,6 +6,9 @@ const (
 
 	// DaemonOkResp is the OK response upon successfully reaching daemon
 	DaemonOkResp = "I'm a little Webhook, short and stout!"
+
+	// DefaultBranch is the branch deployed by default
+	DefaultBranch = "default"
 )
 
 // DaemonRequest is the configurable body of a request to the daemon.
@@ -13,4 +16,5 @@ type DaemonRequest struct {
 	Stream    bool   `json:"stream"`
 	Repo      string `json:"repo,omitempty"`
 	Container string `json:"container,omitempty"`
+	Branch    string `json:"branch"`
 }

--- a/common/types.go
+++ b/common/types.go
@@ -6,15 +6,17 @@ const (
 
 	// DaemonOkResp is the OK response upon successfully reaching daemon
 	DaemonOkResp = "I'm a little Webhook, short and stout!"
-
-	// DefaultBranch is the branch deployed by default
-	DefaultBranch = "default"
 )
 
 // DaemonRequest is the configurable body of a request to the daemon.
 type DaemonRequest struct {
-	Stream    bool   `json:"stream"`
-	Repo      string `json:"repo,omitempty"`
-	Container string `json:"container,omitempty"`
+	Stream     bool        `json:"stream"`
+	Container  string      `json:"container,omitempty"`
+	GitOptions *GitOptions `json:"git_options"`
+}
+
+// GitOptions represents GitHub-related deployment options
+type GitOptions struct {
+	RemoteURL string `json:"remote"`
 	Branch    string `json:"branch"`
 }

--- a/daemon/docker.go
+++ b/daemon/docker.go
@@ -55,16 +55,16 @@ func deploy(repo *git.Repository, branch string, cli *docker.Client, out io.Writ
 	// separate from the daemon and the user's project, and is the
 	// second container to require access to the docker socket.
 	// See https://cloud.google.com/community/tutorials/docker-compose-on-container-optimized-os
-	fmt.Fprintln(out, "Building project...")
+	fmt.Fprintln(out, "Setting up docker-compose...")
 	ctx := context.Background()
 	resp, err := cli.ContainerCreate(
 		ctx, &container.Config{
 			Image:      dockerCompose,
 			WorkingDir: "/build/project",
+			Env:        []string{"HOME=/build"},
 			Cmd: []string{
 				"up",
 				"--build",
-				"-e HOME=/build",
 			},
 		},
 		&container.HostConfig{
@@ -82,10 +82,8 @@ func deploy(repo *git.Repository, branch string, cli *docker.Client, out io.Writ
 		return errors.New(warnings)
 	}
 
-	err = cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{})
-	if err != nil {
-		return err
-	}
+	fmt.Fprintln(out, "Building project...")
+	return cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{})
 
 	// Check if build failed abruptly
 	// This is disabled until a more consistent way of detecting build
@@ -100,9 +98,9 @@ func deploy(repo *git.Repository, branch string, cli *docker.Client, out io.Writ
 			}
 			return errors.New("Docker-compose failed: " + err.Error())
 		}
+		return nil
 	*/
 
-	return nil
 }
 
 // getActiveContainers returns all active containers and returns and error

--- a/daemon/docker.go
+++ b/daemon/docker.go
@@ -30,7 +30,7 @@ func deploy(repo *git.Repository, branch string, cli *docker.Client, out io.Writ
 
 	fmt.Fprintln(out, "Updating repository...")
 	// Pull from working branch
-	err = updateRepository(repo, branch, auth, out)
+	err = common.UpdateRepository(projectDirectory, repo, branch, auth, out)
 	if err != nil {
 		return err
 	}

--- a/daemon/docker.go
+++ b/daemon/docker.go
@@ -27,8 +27,8 @@ func deploy(repo *git.Repository, branch string, cli *docker.Client, out io.Writ
 		return err
 	}
 
+	// Pull from given branch
 	fmt.Fprintln(out, "Updating repository...")
-	// Pull from working branch
 	err = common.UpdateRepository(projectDirectory, repo, branch, auth, out)
 	if err != nil {
 		return err

--- a/daemon/docker.go
+++ b/daemon/docker.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -89,15 +88,19 @@ func deploy(repo *git.Repository, branch string, cli *docker.Client, out io.Writ
 	}
 
 	// Check if build failed abruptly
-	time.Sleep(3 * time.Second)
-	_, err = getActiveContainers(cli)
-	if err != nil {
-		killErr := killActiveContainers(cli, out)
-		if killErr != nil {
-			fmt.Fprintln(out, err)
+	// This is disabled until a more consistent way of detecting build
+	// failures is implemented.
+	/*
+		time.Sleep(3 * time.Second)
+		_, err = getActiveContainers(cli)
+		if err != nil {
+			killErr := killActiveContainers(cli, out)
+			if killErr != nil {
+				fmt.Fprintln(out, err)
+			}
+			return errors.New("Docker-compose failed: " + err.Error())
 		}
-		return errors.New("Docker-compose failed: " + err.Error())
-	}
+	*/
 
 	return nil
 }

--- a/daemon/handler.go
+++ b/daemon/handler.go
@@ -121,7 +121,7 @@ func upHandler(w http.ResponseWriter, r *http.Request) {
 	// Check for existing git repository, clone if no git repository exists.
 	err = common.CheckForGit(projectDirectory)
 	if err != nil {
-		fmt.Fprintln(w, "No git repository present.")
+		logger.Println("No git repository present.")
 		err = setUpProject(gitOpts.RemoteURL, gitOpts.Branch, logger.GetWriter())
 		if err != nil {
 			logger.Err(err.Error(), http.StatusPreconditionFailed)

--- a/daemon/helper.go
+++ b/daemon/helper.go
@@ -113,6 +113,7 @@ func GetAPIPrivateKey(*jwt.Token) (interface{}, error) {
 
 // setUpProject sets up a project for the first time
 func setUpProject(remoteURL, branch string, w io.Writer) error {
+	fmt.Fprintln(w, "Setting up project...")
 	pemFile, err := os.Open(daemonGithubKeyLocation)
 	if err != nil {
 		return err
@@ -137,7 +138,7 @@ func setUpProject(remoteURL, branch string, w io.Writer) error {
 func gitAuthFailedErr(keyloc string) error {
 	bytes, err := ioutil.ReadFile(keyloc + ".pub")
 	if err != nil {
-		bytes = []byte("Error reading key - try running 'inertia [REMOTE] init' again.")
+		bytes = []byte(err.Error() + "\nError reading key - try running 'inertia [REMOTE] init' again: ")
 	}
 	return errors.New("Access to project repository rejected; did you forget to add\nInertia's deploy key to your repository settings?\n" + string(bytes[:]))
 }

--- a/daemon/helper.go
+++ b/daemon/helper.go
@@ -123,7 +123,6 @@ func setUpProject(remoteURL, branch string, w io.Writer) error {
 	}
 
 	// Clone project
-	fmt.Fprintln(w, "Cloning "+remoteURL+"...")
 	_, err = common.Clone(projectDirectory, remoteURL, branch, auth, w)
 	if err != nil {
 		if err == common.ErrInvalidGitAuthentication {

--- a/main.go
+++ b/main.go
@@ -24,6 +24,9 @@ use 'inertia [REMOTE] --help' to see what you can do with your remote.`,
 }
 
 func main() {
+	if Version == "" {
+		Version = "unknown"
+	}
 	cobra.EnableCommandSorting = false
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/remote_test.go
+++ b/remote_test.go
@@ -24,11 +24,12 @@ func TestRemoteAddWalkthrough(t *testing.T) {
 	fmt.Fprintln(in, "pemfile")
 	fmt.Fprintln(in, "user")
 	fmt.Fprintln(in, "0.0.0.0")
+	fmt.Fprintln(in, "master")
 
 	_, err = in.Seek(0, io.SeekStart)
 	assert.Nil(t, err)
 
-	err = addRemoteWalkthrough(in, "inertia-rocks", "8080", "22", mockCallback)
+	err = addRemoteWalkthrough(in, "inertia-rocks", "8080", "22", "dev", mockCallback)
 	assert.Nil(t, err)
 }
 
@@ -46,13 +47,13 @@ func TestRemoteAddWalkthroughFailure(t *testing.T) {
 	_, err = in.Seek(0, io.SeekStart)
 	assert.Nil(t, err)
 
-	err = addRemoteWalkthrough(in, "inertia-rocks", "8080", "22", mockCallback)
+	err = addRemoteWalkthrough(in, "inertia-rocks", "8080", "22", "dev", mockCallback)
 	assert.Equal(t, errInvalidUser, err)
 
 	in.WriteAt([]byte("pemfile\nuser\n\n"), 0)
 	_, err = in.Seek(0, io.SeekStart)
 	assert.Nil(t, err)
 
-	err = addRemoteWalkthrough(in, "inertia-rocks", "8080", "22", mockCallback)
+	err = addRemoteWalkthrough(in, "inertia-rocks", "8080", "22", "dev", mockCallback)
 	assert.Equal(t, errInvalidAddress, err)
 }

--- a/remote_test.go
+++ b/remote_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/ubclaunchpad/inertia/client"
 )
 
 func TestRemoteAddWalkthrough(t *testing.T) {
-	mockCallback := func(name, address, sshPort, user, pemLoc, port string) error {
-		assert.Equal(t, "pemfile", pemLoc)
-		assert.Equal(t, "user", user)
-		assert.Equal(t, "0.0.0.0", address)
+	mockCallback := func(r *client.RemoteVPS) error {
+		assert.Equal(t, "pemfile", r.PEM)
+		assert.Equal(t, "user", r.User)
+		assert.Equal(t, "0.0.0.0", r.IP)
 		return nil
 	}
 	in, err := ioutil.TempFile("", "")
@@ -32,7 +33,7 @@ func TestRemoteAddWalkthrough(t *testing.T) {
 }
 
 func TestRemoteAddWalkthroughFailure(t *testing.T) {
-	mockCallback := func(name, address, sshPort, user, pemLoc, port string) error {
+	mockCallback := func(r *client.RemoteVPS) error {
 		return nil
 	}
 	in, err := ioutil.TempFile("", "")


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #83

---

## :construction_worker: Changes

- You can now specify which branch you want deployed when running `inertia remote add`
- Daemon will now pull/checkout/clone requested branches 
   - [x] Fine tune the specifics of when to change branches etc, right now the daemon just does it whenever (UPDATE: Current behaviour should be acceptable - branch config is read from config each time)
   - [x] what happens when daemon receives a webhook before `up`? (UPDATE: ignore that shizzle)

## :flashlight: Testing Instructions

```bash
$ inertia remote add local
# specify a branch during setup

$ inertia local up
# your specified branch is deployed!
```
