### PR TITLE
Populate links to settings with [user]/[project] replacing <your-repo>

### DIFF
--- a/client/remote.go
+++ b/client/remote.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/ubclaunchpad/inertia/common"
 )
 
 // RemoteVPS contains parameters for the VPS
@@ -85,12 +86,16 @@ func (remote *RemoteVPS) Bootstrap(runner SSHSession, name string, config *Confi
 
 	println("=============================\n")
 
+	repo, err := common.GetLocalRepo()
+	origin, err := repo.Remote("origin")
+	projectName := common.Extract(common.GetSSHRemoteURL(origin.Config().URLs[0]))
+
 	// Output deploy key to user.
-	println(">> GitHub Deploy Key (add to https://www.github.com/<your_repo>/settings/keys/new): ")
+	println(">> GitHub Deploy Key (add to https://www.github.com/" + projectName + "/settings/keys/new): ")
 	println(pub.String())
 
 	// Output Webhook url to user.
-	println(">> GitHub WebHook URL (add to https://www.github.com/<your_repo>/settings/hooks/new): ")
+	println(">> GitHub WebHook URL (add to https://www.github.com/" + projectName + "/settings/hooks/new): ")
 	println("WebHook Address:  https://" + remote.IP + ":" + remote.Daemon.Port)
 	println("WebHook Secret:   " + remote.Daemon.Secret)
 	println(`Note that you will have to disable SSH verification in your webhook

--- a/common/util.go
+++ b/common/util.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 )
 
 // CheckForDockerCompose returns error if current directory is a
@@ -78,4 +79,10 @@ func Flush(w io.Writer, rc io.ReadCloser, buffer []byte) error {
 		buffer[i] = 0
 	}
 	return nil
+}
+
+// Extract gets the project name from its URL in the form [username]/[project]
+func Extract(URL string) string {
+	r, _ := regexp.Compile(".com(/|:)(\\w+/\\w+)")
+	return r.FindStringSubmatch(URL)[2]
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -87,3 +87,9 @@ func TestFlushRoutine(t *testing.T) {
 		i++
 	}
 }
+
+func TestExtract(t *testing.T) {
+	for _, url := range urlVariations {
+		assert.Equal(t, "ubclaunchpad/inertia", Extract(url))
+	}
+}


### PR DESCRIPTION
… will take the place of <your-repo> portion of the link to settings

:tickets: **Ticket(s)**: Closes #123 

---

## :construction_worker: Changes

Added an Extract(URL) function inside util.go that pulls the username and project name from the repo's url. This function is called in remote.go to prepopulate the links to settings. Not sure if im retreiving the URL correctly in remote.go though. 

## :flashlight: Testing Instructions

TestExtract function in util_test.go checks the list of url variations to see that ubclaunchpad/inertia is returned 
