### PR TITLE
#176 querystring (for GET requests)

### DIFF
--- a/client/deployment_test.go
+++ b/client/deployment_test.go
@@ -205,14 +205,8 @@ func TestLogs(t *testing.T) {
 		assert.Equal(t, "/logs", endpoint)
 
 		// Check body
-		body, err := ioutil.ReadAll(req.Body)
-		assert.Nil(t, err)
 		defer req.Body.Close()
-		var upReq common.DaemonRequest
-		err = json.Unmarshal(body, &upReq)
-		assert.Nil(t, err)
-		assert.Equal(t, "docker-compose", upReq.Container)
-		assert.Equal(t, true, upReq.Stream)
+		assert.Equal(t, "Container=docker-compose&Stream=true", req.URL.RawQuery)
 
 		// Check auth
 		assert.Equal(t, "Bearer "+fakeAuth, req.Header.Get("Authorization"))

--- a/client/deployment_test.go
+++ b/client/deployment_test.go
@@ -206,7 +206,9 @@ func TestLogs(t *testing.T) {
 
 		// Check body
 		defer req.Body.Close()
-		assert.Equal(t, "Container=docker-compose&Stream=true", req.URL.RawQuery)
+		q := req.URL.Query()
+		assert.Equal(t, "docker-compose", q.Get(common.Container))
+		assert.Equal(t, "true", q.Get(common.Stream))
 
 		// Check auth
 		assert.Equal(t, "Bearer "+fakeAuth, req.Header.Get("Authorization"))

--- a/common/request.go
+++ b/common/request.go
@@ -3,6 +3,10 @@ package common
 const (
 	// MsgDaemonOK is the OK response upon successfully reaching daemon
 	MsgDaemonOK = "I'm a little Webhook, short and stout!"
+
+	// Constants used in HTTP GET query strings
+	Container = "container"
+	Stream    = "stream"
 )
 
 // DaemonRequest is the configurable body of a request to the daemon.

--- a/daemon/inertia/logs.go
+++ b/daemon/inertia/logs.go
@@ -15,7 +15,6 @@ import (
 // logHandler handles requests for container logs
 func logHandler(w http.ResponseWriter, r *http.Request) {
 	// Get container name and stream from request query params
-	//var upReq common.DaemonRequest
 	q := r.URL.Query()
 
 	container := q.Get("Container")

--- a/daemon/inertia/logs.go
+++ b/daemon/inertia/logs.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	docker "github.com/docker/docker/client"
 	"github.com/ubclaunchpad/inertia/common"
 	"github.com/ubclaunchpad/inertia/daemon/inertia/project"
-	"strconv"
 )
 
 // logHandler handles requests for container logs
@@ -17,8 +17,8 @@ func logHandler(w http.ResponseWriter, r *http.Request) {
 	// Get container name and stream from request query params
 	q := r.URL.Query()
 
-	container := q.Get("Container")
-	stream, err := strconv.ParseBool(q.Get("Stream"))
+	container := q.Get("container")
+	stream, err := strconv.ParseBool(q.Get("stream"))
 	if err != nil {
 		println(err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/daemon/web/client.js
+++ b/daemon/web/client.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import encodeURL from './common/encodeURL';
 
 export default class InertiaClient {
   constructor(url) {
@@ -36,16 +37,17 @@ export default class InertiaClient {
 
   async getContainerLogs(container = '/inertia-daemon') {
     const endpoint = '/logs';
+    const queryParams = {
+      stream: 'true',
+      container: container,
+    };
     const params = {
       headers: {
         'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        stream: true,
-        container: container,
-      })
+      }
     };
-    return this._post(endpoint, params);
+
+    return this._post(endpoint, params, queryParams);
   }
 
   async getRemoteStatus() {
@@ -63,11 +65,16 @@ export default class InertiaClient {
    * Makes a GET request to the given API endpoint with the given params.
    * @param {String} endpoint
    * @param {Object} params
+   * @param {{[key]: string}} queryParams
    */
-  async _get(endpoint, params) {
+  async _get(endpoint, params, queryParams) {
+    const queryString = queryParams ? encodeURL(queryParams) : '';
+    const url = this.url + endpoint + queryString;
+
     params.method = 'GET';
     params.credentials = 'include';
-    const request = new Request(this.url + endpoint, params);
+
+    const request = new Request(url, params);
 
     try {
       return await fetch(request);

--- a/daemon/web/common/encodeURL.js
+++ b/daemon/web/common/encodeURL.js
@@ -1,0 +1,29 @@
+/**
+ * Encodes the provided key-value pairs into an encoded
+ * query string.
+ *
+ * >> encodeURL({tree: "bear", "penguin party": "igloo"});
+ * >> // returns "tree=bear&penguin%20party=igloo"
+ *
+ * @param {{[key]: string}} params - An object containing
+ * key-value pairs of the desired query params.
+ * @returns {string} - Returns the encoded query string.
+ */
+function encodeURL(params) {
+  const result = [];
+
+  const keys = Object.keys(params);
+  for (let k of keys) {
+    const v = params[k];
+
+    if (typeof v !== 'string') {
+      throw new Error(`Arguments must be of type string, received [${k}, ${typeof v}]`);
+    }
+
+    result.push(encodeURIComponent(k) + '=' + encodeURIComponent(v));
+  }
+
+  return result.join('&')
+}
+
+module.exports = encodeURL;


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #176 
---

## :construction_worker: Changes
- requests are now split into separate get/post functions in the `deployment.go` file
- GET requests now process query strings
- daemon endpoints updated accordingly
- changes are only relevant to the logging functionality

## :flashlight: Testing Instructions
- run tests as usual