### PR TITLE
Faster deploys

### DIFF
--- a/daemon/inertia/project/build_test.go
+++ b/daemon/inertia/project/build_test.go
@@ -60,7 +60,11 @@ func TestDockerComposeIntegration(t *testing.T) {
 	}
 
 	// Execute build
-	err = dockerCompose(d, cli, os.Stdout)
+	deploy, err := dockerCompose(d, cli, os.Stdout)
+	assert.Nil(t, err)
+
+	// Execute deploy
+	err = deploy()
 	assert.Nil(t, err)
 
 	// Arbitrary wait for containers to start
@@ -128,7 +132,11 @@ func TestDockerBuildIntegration(t *testing.T) {
 	}
 
 	// Execute build
-	err = dockerBuild(d, cli, os.Stdout)
+	deploy, err := dockerBuild(d, cli, os.Stdout)
+	assert.Nil(t, err)
+
+	// Execute deploy
+	err = deploy()
 	assert.Nil(t, err)
 
 	// Arbitrary wait for containers to start
@@ -174,7 +182,11 @@ func TestHerokuishBuildIntegration(t *testing.T) {
 	}
 
 	// Execute build
-	err = herokuishBuild(d, cli, os.Stdout)
+	deploy, err := herokuishBuild(d, cli, os.Stdout)
+	assert.Nil(t, err)
+
+	// Execute deploy
+	err = deploy()
 	assert.Nil(t, err)
 
 	// Arbitrary wait for containers to start

--- a/daemon/inertia/project/deployment.go
+++ b/daemon/inertia/project/deployment.go
@@ -36,6 +36,7 @@ type Deployment struct {
 	buildType string
 
 	builders map[string]Builder
+	containerStopper
 
 	repo *git.Repository
 	auth ssh.AuthMethod
@@ -127,7 +128,7 @@ func (d *Deployment) Deploy(cli *docker.Client, out io.Writer, opts DeployOption
 	}
 
 	// Kill active project containers if there are any
-	err := stopActiveContainers(cli, out)
+	err := d.containerStopper(cli, out)
 	if err != nil {
 		return err
 	}
@@ -151,13 +152,13 @@ func (d *Deployment) Down(cli *docker.Client, out io.Writer) error {
 	// active
 	_, err := getActiveContainers(cli)
 	if err != nil {
-		killErr := stopActiveContainers(cli, out)
+		killErr := d.containerStopper(cli, out)
 		if killErr != nil {
 			println(err)
 		}
 		return err
 	}
-	return stopActiveContainers(cli, out)
+	return d.containerStopper(cli, out)
 }
 
 // Destroy shuts down the deployment and removes the repository

--- a/daemon/inertia/project/deployment.go
+++ b/daemon/inertia/project/deployment.go
@@ -71,15 +71,21 @@ func NewDeployment(cfg DeploymentConfig, out io.Writer) (*Deployment, error) {
 	}
 
 	return &Deployment{
+		// Properties
 		directory: directory,
 		project:   cfg.ProjectName,
 		branch:    cfg.Branch,
 		buildType: cfg.BuildType,
+
+		// Functions
 		builders: map[string]Builder{
 			"herokuish":      herokuishBuild,
 			"dockerfile":     dockerBuild,
 			"docker-compose": dockerCompose,
 		},
+		containerStopper: stopActiveContainers,
+
+		// Repository
 		auth: authMethod,
 		repo: repo,
 	}, nil

--- a/daemon/inertia/project/deployment_test.go
+++ b/daemon/inertia/project/deployment_test.go
@@ -1,10 +1,14 @@
 package project
 
 import (
+	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	git "gopkg.in/src-d/go-git.v4"
+
+	docker "github.com/docker/docker/client"
 )
 
 func TestSetConfig(t *testing.T) {
@@ -18,6 +22,78 @@ func TestSetConfig(t *testing.T) {
 	assert.Equal(t, "wow", deployment.project)
 	assert.Equal(t, "amazing", deployment.branch)
 	assert.Equal(t, "best", deployment.buildType)
+}
+
+func TestDeploySkipUpdate(t *testing.T) {
+	buildCalled := false
+	stopCalled := false
+	d := Deployment{
+		directory: "./test/",
+		buildType: "test",
+		builders: map[string]Builder{
+			"test": func(*Deployment, *docker.Client, io.Writer) (func() error, error) {
+				return func() error {
+					buildCalled = true
+					return nil
+				}, nil
+			},
+		},
+		containerStopper: func(*docker.Client, io.Writer) error {
+			stopCalled = true
+			return nil
+		},
+	}
+
+	cli, err := docker.NewEnvClient()
+	assert.Nil(t, err)
+	defer cli.Close()
+
+	err = d.Deploy(cli, os.Stdout, DeployOptions{SkipUpdate: true})
+	assert.Nil(t, err)
+	assert.True(t, buildCalled)
+	assert.True(t, stopCalled)
+}
+
+func TestDown(t *testing.T) {
+	called := false
+	d := Deployment{
+		directory: "./test/",
+		buildType: "test",
+		containerStopper: func(*docker.Client, io.Writer) error {
+			called = true
+			return nil
+		},
+	}
+
+	cli, err := docker.NewEnvClient()
+	assert.Nil(t, err)
+	defer cli.Close()
+
+	err = d.Down(cli, os.Stdout)
+	if err != ErrNoContainers {
+		assert.Nil(t, err)
+	}
+
+	assert.True(t, called)
+}
+
+func TestGetStatus(t *testing.T) {
+	// Traverse back down to root directory of repository
+	repo, err := git.PlainOpen("../../../")
+	assert.Nil(t, err)
+
+	cli, err := docker.NewEnvClient()
+	assert.Nil(t, err)
+	defer cli.Close()
+
+	deployment := &Deployment{
+		repo:      repo,
+		buildType: "test",
+	}
+	status, err := deployment.GetStatus(cli)
+	assert.Nil(t, err)
+	assert.False(t, status.BuildContainerActive)
+	assert.Equal(t, "test", status.BuildType)
 }
 
 func TestGetBranch(t *testing.T) {

--- a/daemon/inertia/project/deployment_test.go
+++ b/daemon/inertia/project/deployment_test.go
@@ -24,7 +24,11 @@ func TestSetConfig(t *testing.T) {
 	assert.Equal(t, "best", deployment.buildType)
 }
 
-func TestDeploySkipUpdate(t *testing.T) {
+func TestDeployMockSkipUpdateIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
 	buildCalled := false
 	stopCalled := false
 	d := Deployment{
@@ -54,7 +58,11 @@ func TestDeploySkipUpdate(t *testing.T) {
 	assert.True(t, stopCalled)
 }
 
-func TestDown(t *testing.T) {
+func TestDownIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
 	called := false
 	d := Deployment{
 		directory: "./test/",
@@ -77,7 +85,11 @@ func TestDown(t *testing.T) {
 	assert.True(t, called)
 }
 
-func TestGetStatus(t *testing.T) {
+func TestGetStatusIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
 	// Traverse back down to root directory of repository
 	repo, err := git.PlainOpen("../../../")
 	assert.Nil(t, err)

--- a/daemon/inertia/project/docker.go
+++ b/daemon/inertia/project/docker.go
@@ -58,6 +58,8 @@ func getActiveContainers(cli *docker.Client) ([]types.Container, error) {
 	return containers, nil
 }
 
+type containerStopper func(*docker.Client, io.Writer) error
+
 // stopActiveContainers kills all active project containers (ie not including daemon)
 func stopActiveContainers(cli *docker.Client, out io.Writer) error {
 	fmt.Fprintln(out, "Shutting down active containers...")


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #173

---

## :construction_worker: Changes

This PR refactors some of the build code, adds some tests, and changes the deploy process so that a build is allowed to complete before the old containers are shut down and the new containers are brought up.

Some new interfaces:

```go
// Builder builds projects and returns a callback that can be used to deploy the project.
type Builder func(*Deployment, *docker.Client, io.Writer) (func() error, error)

type containerStopper func(*docker.Client, io.Writer) error
```

## :flashlight: Testing Instructions

```
make test-all
```

Also needs some further testing with real projects, since I'm not sure if container conflicts will come into play. There are tests, but I'm not sure how well they reflect real usage since no actual code changes occur.
