### PR TITLE
Improved setup and contribution guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ However, please do a quick search of past issues before opening a ticket. If you
 
 # Submitting a Pull Request
 
-👍 Contributions of any size are very much appreciated.
+👍 Contributions of any size and scope are very much appreciated!
 
 All pull requests should be connected to one or more issues. Please try to fill out the pull request template to the best of your ability and use a clear, descriptive title.
 
@@ -30,8 +30,8 @@ Read on for a comprehensive guide on how to get started with Inertia's codebase!
 
 Please free free to open up a ticket if any of these instructions are unclear or straight up do not work on your platform!
 
-- [Setup](#setup)
-- [Overview](#overview)
+- [Installation and Setup](#installation-and-setup)
+- [Project Overview](#project-overview)
 - [Testing Environment](#setting-up-a-testing-environment)
 
 ## Setup
@@ -59,7 +59,7 @@ Inertia uses:
 Make sure all of the above are installed before running:
 
 ```bash
-$> make RELEASE=test  # installs dependencies and an Inertia 
+$> make               # installs dependencies and an Inertia 
                       # build tagged as "test" to gopath
 $> inertia --version  # check what version you have installed
 ```
@@ -68,11 +68,17 @@ A build tagged as `test` allows you to use `make testdaemon` for local developme
 
 Note that if you install Inertia using these commands or any variation of `go install`, you may have to remove the binary using `go clean -i github.com/ubclaunchpad/inertia` to use an Inertia CLI installed using Homebrew. To go back to a `go install`ed version of Inertia, you need to run `brew uninstall inertia`.
 
-## Overview
+## Project Overview
+
+[![GoDoc](https://godoc.org/github.com/ubclaunchpad/inertia?status.svg)](https://godoc.org/github.com/ubclaunchpad/inertia)
+
+The Inertia codebase is split up into several components - this section gives a quick introduction on how to work with each.
 
 ### CLI
 
-The codebase for the CLI is in the root directory. This code should only include the CLI user interface - all client-based logic and functionality should go into the `client` package.
+Inertia's command line application is in the root directory. It is built on top of [cobra](https://github.com/spf13/cobra), a library for building command line applications.
+
+This code should only include the CLI user interface and code used to manage local assets, such as configuration files - core client logic, functionality, and daemon API interactions should go into the `client` package.
 
 ### Client
 
@@ -98,12 +104,13 @@ result, _ := remote.RunSSHCommand(string(shellScriptData))
 
 ### Daemon
 
-The Inertia daemon package manages all serverside functionality. The daemon codebase is in `./daemon/inertia/`.
+The Inertia daemon package manages all serverside functionality and is the core of the Inertia platform. The daemon codebase is in `./daemon/inertia/`.
 
-To use a daemon compiled from source, set your Inertia version in `.inertia.toml` to `test` and run:
+To locally test a daemon compiled from source, set your Inertia version in `.inertia.toml` to `test` and run:
 
 ```bash
 $> make testdaemon
+# In your test project directory:
 $> inertia local init
 ```
 
@@ -144,6 +151,7 @@ Make sure you have a local daemon set up for this web app to work - see the prev
 You will need Docker installed and running to run whole the Inertia test suite, which includes a number of integration tests.
 
 ```bash
+$> make dev-deps                              # install various development dependencies
 $> make test-all                              # test against ubuntu:latest
 $> make test-all VPS_OS=ubuntu VERSION=14.04  # test against ubuntu:14.04
 ```
@@ -166,7 +174,7 @@ You can [SSH into this testvps container](https://bobheadxi.github.io/dockercept
 2. **Compile and install Inertia**
 
 ```bash
-$> make RELEASE=test
+$> make
 ```
 
 3. **Build and deliver Inertia daemon to the `testvps`**
@@ -201,4 +209,4 @@ $> inertia local status
 $> inertia local logs
 ```
 
-Please free free to open up an Issue if any of these steps are no clear or don't work!
+Please free free to open up an Issue if any of these steps are not clear or don't work!

--- a/Makefile
+++ b/Makefile
@@ -2,22 +2,26 @@ TAG = `git describe --tags`
 SSH_PORT = 22
 VPS_VERSION = latest
 VPS_OS = ubuntu
-RELEASE = canary
+RELEASE = test
 
-all: deps bootstrap inertia
+all: prod-deps inertia
 
 # List all commands
 .PHONY: ls
 ls:
 	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs
 
-# Sets up all dependencies
-.PHONY: deps
-deps:
-	go get -u github.com/jteeuwen/go-bindata/...
+# Sets up production dependencies
+.PHONY: prod-deps
+prod-deps:
 	dep ensure
 	make web-deps
-	bash test/deps.sh
+
+# Sets up test dependencies
+.PHONY: dev-deps
+dev-deps:
+	go get -u github.com/jteeuwen/go-bindata/...
+	bash test/deps.sh	
 
 # Install Inertia with release version
 .PHONY: inertia

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ all: prod-deps inertia
 ls:
 	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs
 
+# Install all dependencies
+.PHONY: deps
+deps: prod-deps dev-deps
+
 # Sets up production dependencies
 .PHONY: prod-deps
 prod-deps:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  Effortless, self-hosted continuous deployment.
+  An effortless, self-hosted continuous deployment platform.
 </p>
 
 <p align="center">
@@ -15,7 +15,7 @@
   <a href="https://goreportcard.com/report/github.com/ubclaunchpad/inertia">
     <img src="https://goreportcard.com/badge/github.com/ubclaunchpad/inertia" alt="Clean code" />
   </a>
-
+  
   <a href="https://github.com/ubclaunchpad/inertia/blob/master/.github/CONTRIBUTING.md">
     <img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg" />
   </a>
@@ -27,13 +27,21 @@
 
 <br>
 
-----------------
+<p align="center">
+  <a href="#package-getting-started"><strong>Getting Started</strong></a> · 
+  <a href="#bulb-motivation-and-design"><strong>Motivation & Design</strong></a> · 
+  <a href="#books-contributing"><strong>Contributing</strong></a>
+</p>
 
-Inertia is a simple cross-platform command line application that enables quick and easy setup and management of continuous, automated deployment of a variety of project types on any virtual private server. It is used, built, and maintained with :heart: by [UBC Launch Pad](https://www.ubclaunchpad.com/).
+<br>
 
 <p align="center">
     <img src="/.static/inertia-init.png" width="45%" />
 </p>
+
+<br>
+
+Inertia is a simple cross-platform command line application that enables quick and easy setup and management of continuous, automated deployment of a variety of project types on any virtual private server. The project is used, built, and maintained with :heart: by [UBC Launch Pad](https://www.ubclaunchpad.com/).
 
 |   | Main Features  |
 ----|-----------------
@@ -45,17 +53,6 @@ Inertia is a simple cross-platform command line application that enables quick a
 🏷  | Configure deployment to your liking with branch settings and more
 🌐  | Add users and check on your deployment anywhere through Inertia Web
 🔑  | Secured with tokens and HTTPS across the board
-
-----------------
-
-### Contents
-- [Getting Started](#package-getting-started)
-  - [Setup](#setup)
-  - [Continuous Deployment](#continuous-deployment)
-  - [Deployment Management](#deployment-management)
-  - [Release Streams](#release-streams)
-- [Motivation and Design](#bulb-motivation-and-design)
-- [Contributing](#books-contributing)
 
 <br>
 


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #209

---

## :construction_worker: Changes

This PR splits up dependencies installs into `make dev-deps` and `make prod-deps`. Contribution guide has been updated accordingly and slightly improved (link to GoDoc and fixed spelling, for example)

The old `make deps` is still available.

Also did a slight reordering of the README again.

Default install version is now `"test"` so you don't have to write `make RELEASE=test` each time

## :flashlight: Testing Instructions

n/a