### PR TITLE
Warn if configuration file version doesn't match CLI version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VPS_VERSION = latest
 VPS_OS = ubuntu
 RELEASE = test
 
-all: prod-deps inertia
+all: prod-deps cli
 
 # List all commands
 .PHONY: ls
@@ -29,12 +29,12 @@ dev-deps:
 	bash test/lint_deps.sh
 
 # Install Inertia with release version
-.PHONY: inertia
+.PHONY: cli
 inertia:
 	go install -ldflags "-X main.Version=$(RELEASE)"
 
 # Install Inertia with git tag as release version
-.PHONY: inertia-tagged
+.PHONY: cli-tagged
 inertia-tagged:
 	go install -ldflags "-X main.Version=$(TAG)"
 

--- a/deploy.go
+++ b/deploy.go
@@ -21,9 +21,17 @@ import (
 
 // Initialize "inertia [REMOTE] [COMMAND]" commands
 func init() {
+	// This is the only place configuration is read every time an `inertia`
+	// command is run - check version here.
 	config, _, err := local.GetProjectConfigFromDisk()
 	if err != nil {
 		return
+	}
+	if config.Version != Version {
+		fmt.Printf(
+			"[WARNING] Configuration version '%s' does not match your Inertia CLI version '%s'\n",
+			config.Version, Version,
+		)
 	}
 
 	// Make a new command for each remote with all associated


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #167 

---

## :construction_worker: Changes

Warn if your `inertia.toml` version doesn't match your CLI version:

```bash
bobbook:inertia robertlin$ inertia --version
[WARNING] Configuration version 'v0.4.0-rc2' does not match your Inertia CLI version 'test'
inertia version test
bobbook:inertia robertlin$
```

## :flashlight: Testing Instructions

```bash
$ make cli
$ inertia init
$ make cli-tagged
$ inertia --help
# you should be warned
```
