### PR TITLE
Stream commands by default, add option to use "short" version

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -93,11 +93,10 @@ Run 'inertia [REMOTE] init' to gather this information.`,
 		reset := deepCopy(cmdDeploymentReset)
 		cmd.AddCommand(reset)
 
-		// Attach a "stream" option on all commands, even if it doesn't
-		// do anything for some commands yet.
+		// Attach a "short" option on all commands
 		cmd.PersistentFlags().BoolP(
-			"stream", "s", false,
-			"Stream output from daemon - doesn't do anything on some commands.",
+			"short", "s", false,
+			"Don't stream output from command",
 		)
 		cmdRoot.AddCommand(cmd)
 	}
@@ -117,7 +116,7 @@ var cmdDeploymentUp = &cobra.Command{
 		}
 
 		// Get flags
-		stream, err := cmd.Flags().GetBool("stream")
+		short, err := cmd.Flags().GetBool("short")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -135,13 +134,13 @@ var cmdDeploymentUp = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		resp, err := deployment.Up(origin.Config().URLs[0], buildType, stream)
+		resp, err := deployment.Up(origin.Config().URLs[0], buildType, !short)
 		if err != nil {
 			log.Fatal(err)
 		}
 		defer resp.Body.Close()
 
-		if !stream {
+		if short {
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
 				log.Fatal(err)
@@ -266,7 +265,7 @@ var cmdDeploymentLogs = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		stream, err := cmd.Flags().GetBool("stream")
+		short, err := cmd.Flags().GetBool("short")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -276,7 +275,7 @@ var cmdDeploymentLogs = &cobra.Command{
 			container = args[0]
 		}
 
-		if !stream {
+		if short {
 			resp, err := deployment.Logs(container)
 			if err != nil {
 				log.Fatal(err)


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #239

---

## :construction_worker: Changes

- Stream all command output by default
- Add flag "-s" or "--short" that disables streaming

## :flashlight: Testing Instructions

Run through the usual deployment steps, commands should stream by default