### PR TITLE
Remove go-git dependencies in CLI

### DIFF
--- a/common/git.go
+++ b/common/git.go
@@ -1,49 +1,9 @@
 package common
 
 import (
-	"errors"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
-
-	git "gopkg.in/src-d/go-git.v4"
 )
-
-// GetLocalRepo gets the repo from disk.
-func GetLocalRepo() (*git.Repository, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	return git.PlainOpen(cwd)
-}
-
-// CheckForGit returns an error if we're not in a git repository.
-func CheckForGit(cwd string) error {
-	// Quick failure if no .git folder.
-	gitFolder := filepath.Join(cwd, ".git")
-	if _, err := os.Stat(gitFolder); os.IsNotExist(err) {
-		return errors.New("this does not appear to be a git repository")
-	}
-
-	repo, err := git.PlainOpen(cwd)
-	if err != nil {
-		return err
-	}
-
-	remotes, err := repo.Remotes()
-	if err != nil {
-		return err
-	}
-
-	// Also fail if no remotes detected.
-	if len(remotes) == 0 {
-		return errors.New("there are no remotes associated with this repository")
-	}
-
-	return nil
-}
 
 // GetSSHRemoteURL gets the URL of the given remote in the form
 // "git@github.com:[USER]/[REPOSITORY].git"

--- a/common/git_test.go
+++ b/common/git_test.go
@@ -1,8 +1,6 @@
 package common
 
 import (
-	"os"
-	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,14 +22,6 @@ var remoteURLVariations = []string{
 
 	// Bitbucket URL Variations
 	"https://ubclaunchpad@bitbucket.org/ubclaunchpad/inertia.git",
-}
-
-func TestCheckForGit(t *testing.T) {
-	cwd, err := os.Getwd()
-	assert.Nil(t, err)
-	assert.NotEqual(t, nil, CheckForGit(cwd))
-	inertia, _ := path.Split(cwd)
-	assert.Equal(t, nil, CheckForGit(inertia))
 }
 
 func TestGetSSHRemoteURL(t *testing.T) {

--- a/deploy.go
+++ b/deploy.go
@@ -138,16 +138,13 @@ var cmdDeploymentUp = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		repo, err := common.GetLocalRepo()
-		if err != nil {
-			log.Fatal(err)
-		}
 		// TODO: support other remotes
-		origin, err := repo.Remote("origin")
+		url, err := local.GetRepoRemote("origin")
 		if err != nil {
 			log.Fatal(err)
 		}
-		resp, err := deployment.Up(origin.Config().URLs[0], buildType, !short)
+
+		resp, err := deployment.Up(url, buildType, !short)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -408,15 +405,11 @@ for updates to this repository's remote master branch.`,
 		}
 		cli, found := client.NewClient(remoteName, config)
 		if found {
-			repo, err := common.GetLocalRepo()
+			url, err := local.GetRepoRemote("origin")
 			if err != nil {
 				log.Fatal(err)
 			}
-			origin, err := repo.Remote("origin")
-			if err != nil {
-				log.Fatal(err)
-			}
-			repoName := common.ExtractRepository(common.GetSSHRemoteURL(origin.Config().URLs[0]))
+			repoName := common.ExtractRepository(common.GetSSHRemoteURL(url))
 			err = cli.BootstrapRemote(repoName)
 			if err != nil {
 				log.Fatal(err)

--- a/local/git.go
+++ b/local/git.go
@@ -1,0 +1,48 @@
+package local
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// GetRepoRemote reads a remote URL
+func GetRepoRemote(remote string) (string, error) {
+	arg := "remote." + remote + ".url"
+	out, err := exec.Command("git", "config", "--get", arg).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// GetRepoCurrentBranch returns the current repository branch
+func GetRepoCurrentBranch() (string, error) {
+	out, err := exec.Command("git", "symbolic-ref", "--short", "HEAD").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// checkForGit returns an error if we're not in a git repository.
+func checkForGit(cwd string) error {
+	// Quick failure if no .git folder.
+	gitFolder := filepath.Join(cwd, ".git")
+	if _, err := os.Stat(gitFolder); os.IsNotExist(err) {
+		return errors.New("this does not appear to be a git repository")
+	}
+
+	// Also fail if no origin detected
+	url, err := GetRepoRemote("origin")
+	if err != nil {
+		return err
+	}
+	if url == "" {
+		return errors.New("no remote origin set")
+	}
+
+	return nil
+}

--- a/local/git.go
+++ b/local/git.go
@@ -11,18 +11,18 @@ import (
 // GetRepoRemote reads a remote URL
 func GetRepoRemote(remote string) (string, error) {
 	arg := "remote." + remote + ".url"
-	out, err := exec.Command("git", "config", "--get", arg).Output()
+	out, err := exec.Command("git", "config", "--get", arg).CombinedOutput()
 	if err != nil {
-		return "", err
+		return "", errors.New(err.Error() + ": " + string(out))
 	}
 	return strings.TrimSpace(string(out)), nil
 }
 
 // GetRepoCurrentBranch returns the current repository branch
 func GetRepoCurrentBranch() (string, error) {
-	out, err := exec.Command("git", "symbolic-ref", "--short", "HEAD").Output()
+	out, err := exec.Command("git", "symbolic-ref", "--short", "HEAD").CombinedOutput()
 	if err != nil {
-		return "", err
+		return "", errors.New(err.Error() + ": " + string(out))
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/local/git_test.go
+++ b/local/git_test.go
@@ -1,0 +1,32 @@
+package local
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRepoRemote(t *testing.T) {
+	url, err := GetRepoRemote("origin")
+	assert.Nil(t, err)
+	assert.Contains(t, url, "ubclaunchpad/inertia")
+}
+
+func TestGetRepoCurrentBranch(t *testing.T) {
+	_, err := GetRepoCurrentBranch()
+	if err != nil {
+		fmt.Print(err)
+	}
+	assert.Nil(t, err)
+}
+
+func TestCheckForGit(t *testing.T) {
+	cwd, err := os.Getwd()
+	assert.Nil(t, err)
+	assert.NotNil(t, checkForGit(cwd))
+	inertia, _ := path.Split(cwd)
+	assert.Nil(t, checkForGit(inertia))
+}

--- a/local/git_test.go
+++ b/local/git_test.go
@@ -16,6 +16,11 @@ func TestGetRepoRemote(t *testing.T) {
 }
 
 func TestGetRepoCurrentBranch(t *testing.T) {
+	// This test does not work on Travis, since Travis cloning doesn't always
+	// set up branches correctly (typically detached)
+	if os.Getenv("TRAVIS") == "true" {
+		t.Skip("skipping test because of Travis")
+	}
 	_, err := GetRepoCurrentBranch()
 	if err != nil {
 		fmt.Print(err)

--- a/local/storage.go
+++ b/local/storage.go
@@ -11,7 +11,6 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/ubclaunchpad/inertia/cfg"
 	"github.com/ubclaunchpad/inertia/client"
-	"github.com/ubclaunchpad/inertia/common"
 )
 
 const configFileName = "inertia.toml"
@@ -23,7 +22,7 @@ func InitializeInertiaProject(version, buildType, buildFilePath string) error {
 	if err != nil {
 		return err
 	}
-	err = common.CheckForGit(cwd)
+	err = checkForGit(cwd)
 	if err != nil {
 		return err
 	}

--- a/remote.go
+++ b/remote.go
@@ -7,7 +7,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/ubclaunchpad/inertia/common"
 	"github.com/ubclaunchpad/inertia/local"
 )
 
@@ -62,17 +61,12 @@ file. Specify a VPS name.`,
 
 		port, _ := cmd.Flags().GetString("port")
 		sshPort, _ := cmd.Flags().GetString("sshPort")
-
-		repo, err := common.GetLocalRepo()
+		branch, err := local.GetRepoCurrentBranch()
 		if err != nil {
 			log.Fatal(err)
 		}
-		head, err := repo.Head()
-		if err != nil {
-			log.Fatal(err)
-		}
-		branch := head.Name().Short()
 
+		// Start prompts and save configuration
 		err = addRemoteWalkthrough(os.Stdin, config, args[0], port, sshPort, branch)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #262

---

## :construction_worker: Changes

Most Inertia users will have git installed - no need to package a complete git implementation alongside the CLI. This change replaces previous go-git functions with shell commands.

## :flashlight: Testing Instructions

make test (only unit test changes were made)
