### PR TITLE
Deliver file to absolute path on host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,10 @@ users.db
 # Vendored dependencies
 vendor
 
-# Test output
+# Tests
 .inertia
+inertia.toml
+bumper
 
 # Development
 .vscode

--- a/client/ssh.go
+++ b/client/ssh.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/ubclaunchpad/inertia/cfg"
 	"golang.org/x/crypto/ssh"
@@ -124,14 +124,15 @@ func (runner *SSHRunner) CopyFile(file io.Reader, remotePath string, permissions
 	}
 	reader := bytes.NewReader(contents)
 
-	// Send file contents
-	filename := path.Base(remotePath)
-	directory := path.Dir(remotePath)
+	// Set up
+	filename := filepath.Base(remotePath)
+	directory := filepath.Dir(remotePath)
 	session, err := getSSHSession(runner.pem, runner.ip, runner.sshPort, runner.user)
 	if err != nil {
 		return err
 	}
 
+	// Send file contents
 	go func() {
 		w, _ := session.StdinPipe()
 		defer w.Close()
@@ -139,7 +140,7 @@ func (runner *SSHRunner) CopyFile(file io.Reader, remotePath string, permissions
 		io.Copy(w, reader)
 		fmt.Fprintln(w, "\x00")
 	}()
-	session.Run("/usr/bin/scp -t " + directory)
+	session.Run("mkdir -p " + directory + "; /usr/bin/scp -t " + directory)
 	return nil
 }
 

--- a/deploy.go
+++ b/deploy.go
@@ -390,7 +390,7 @@ deployment. Provide a relative path to your file.`,
 		}
 
 		// Destination path - todo: allow config
-		projectPath := "/app/host/inertia/project"
+		projectPath := "$HOME/inertia/project"
 		remotePath := path.Join(projectPath, dest)
 
 		// Initiate copy

--- a/deploy.go
+++ b/deploy.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/ubclaunchpad/inertia/common"
@@ -379,13 +378,7 @@ deployment. Provide a relative path to your file.`,
 		if err != nil {
 			log.Fatal(err.Error())
 		}
-		if dest != "" {
-			// If path is defined, dest = [path]/[filename], with the user-provided
-			// path to the source file stripped out
-			dest = path.Join(dest, filepath.Base(args[0]))
-		} else {
-			// Otherwise, dest = [filepath], where [filepath] is what the user
-			// provided to the command
+		if dest == "" {
 			dest = args[0]
 		}
 


### PR DESCRIPTION
## :construction_worker: Changes

Command is executed over SSH and does not interact with the containerized daemon - /app/host/ is inappropriate here

see https://github.com/ubclaunchpad/inertia/pull/270#issuecomment-399656231 - closes #271

## :flashlight: Testing Instructions

I just used @brian-nguyen's configuration to send Inertia's `CONTRIBUTING.md` over to the bumper deployment

```
bobbook:inertia robertlin$ inertia aws send CONTRIBUTING.md
[WARNING] Configuration version 'latest' does not match your Inertia CLI version 'test'
File CONTRIBUTING.md has been copied to $HOME/inertia/project/CONTRIBUTING.md on remote aws
bobbook:inertia robertlin$ inertia aws ssh
[WARNING] Configuration version 'latest' does not match your Inertia CLI version 'test'
Last login: Sat Jun 23 08:16:08 2018 from 24.86.161.145

       __|  __|_  )
       _|  (     /   Amazon Linux AMI
      ___|\___|___|

https://aws.amazon.com/amazon-linux-ami/2017.09-release-notes/
28 package(s) needed for security, out of 37 available
Run "sudo yum update" to apply all updates.
Amazon Linux version 2018.03 is available.
[ec2-user@ip-172-31-4-61 ~]$ cd in/project
[ec2-user@ip-172-31-4-61 project]$ ls
client                  Dockerfile
CONTRIBUTING.md         Makefile
docker-compose.dev.yml  README.md
docker-compose.yml      server
[ec2-user@ip-172-31-4-61 project]$ cat CONTRIBUTING.md
# :books: Contributing

This document outlines key considerations and tips for anyone contributing to Inertia.

- [Opening an Issue](#opening-an-issue)
- [Submitting a Pull Request](#submitting-a-pull-request)
- [Development Tips](#development-tips)

------

# Opening an Issue
# ...etc etc
```