### PR TITLE
Allow variable config path via --config flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ vendor
 
 # Tests
 .inertia
-inertia.toml
+inertia*.toml
 bumper
 
 # Development

--- a/common/util.go
+++ b/common/util.go
@@ -8,6 +8,15 @@ import (
 	"path/filepath"
 )
 
+// GetFullPath returns the absolute path of the config file.
+func GetFullPath(relPath string) (string, error) {
+	path, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(path, relPath), nil
+}
+
 // GenerateRandomString creates a rand.Reader-generated
 // string for use with simple secrets and identifiers
 func GenerateRandomString() (string, error) {

--- a/config.go
+++ b/config.go
@@ -94,7 +94,7 @@ var cmdReset = &cobra.Command{
 		if response != "y" {
 			log.Fatal("aborting")
 		}
-		path, err := local.GetConfigFilePath()
+		path, err := local.GetConfigFilePath(ConfigFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -110,7 +110,7 @@ var cmdSetConfigProperty = &cobra.Command{
 	Args:  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure project initialized.
-		config, path, err := local.GetProjectConfigFromDisk()
+		config, path, err := local.GetProjectConfigFromDisk(ConfigFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/config.go
+++ b/config.go
@@ -65,7 +65,7 @@ to succeed.`,
 		}
 
 		// Hello world config file!
-		err = local.InitializeInertiaProject(version, buildType, buildFilePath)
+		err = local.InitializeInertiaProject(ConfigFilePath, version, buildType, buildFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -94,7 +94,7 @@ var cmdReset = &cobra.Command{
 		if response != "y" {
 			log.Fatal("aborting")
 		}
-		path, err := local.GetConfigFilePath(ConfigFilePath)
+		path, err := common.GetFullPath(ConfigFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/deploy.go
+++ b/deploy.go
@@ -19,12 +19,26 @@ import (
 	"github.com/ubclaunchpad/inertia/client"
 )
 
+// parseConfigArg is a dirty dirty hack to allow access to the --config argument
+// before Cobra parses it (it is required to set up remote commands in the
+// init() phase)
+func parseConfigArg() {
+	for i, arg := range os.Args {
+		if arg == "--config" {
+			ConfigFilePath = os.Args[i+1]
+			break
+		}
+	}
+}
+
 // Initialize "inertia [REMOTE] [COMMAND]" commands
 func init() {
 	// This is the only place configuration is read every time an `inertia`
 	// command is run - check version here.
-	config, _, err := local.GetProjectConfigFromDisk()
+	parseConfigArg() // see parseArgs documentation
+	config, _, err := local.GetProjectConfigFromDisk(ConfigFilePath)
 	if err != nil {
+		println("[WARNING] Inertia configuration not found in " + ConfigFilePath)
 		return
 	}
 	if config.Version != Version {
@@ -124,7 +138,7 @@ var cmdDeploymentUp = &cobra.Command{
 	to be active on your remote - do this by running 'inertia [REMOTE] init'`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, cmd)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -188,7 +202,7 @@ var cmdDeploymentDown = &cobra.Command{
 	Requires project to be online - do this by running 'inertia [REMOTE] up`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, cmd)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -225,7 +239,7 @@ var cmdDeploymentStatus = &cobra.Command{
 	running 'inertia [REMOTE] up'`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, cmd)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -272,7 +286,7 @@ var cmdDeploymentLogs = &cobra.Command{
 	status' to see what containers are accessible.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, cmd)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -332,7 +346,7 @@ var cmdDeploymentSSH = &cobra.Command{
 	Long:  `Starts up an interact SSH session with your remote.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -352,7 +366,7 @@ deployment. Provide a relative path to your file.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, cmd)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -410,7 +424,7 @@ for updates to this repository's remote master branch.`,
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
 
 		// Bootstrap needs to write to configuration.
-		config, path, err := local.GetProjectConfigFromDisk()
+		config, path, err := local.GetProjectConfigFromDisk(ConfigFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -442,7 +456,7 @@ remote. Requires Inertia daemon to be active on your remote - do this by
 running 'inertia [REMOTE] init'`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, cmd)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/env.go
+++ b/env.go
@@ -23,7 +23,7 @@ variables are applied to all deployed containers.`,
 	Args: cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, cmd)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -55,7 +55,7 @@ and persistent environment storage.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, cmd)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -79,7 +79,7 @@ var cmdDeploymentEnvList = &cobra.Command{
 	Short: "List currently set and saved environment variables",
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, cmd)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/local/storage.go
+++ b/local/storage.go
@@ -13,7 +13,14 @@ import (
 	"github.com/ubclaunchpad/inertia/client"
 )
 
-const configFileName = "inertia.toml"
+// GetConfigFilePath returns the absolute path of the config file.
+func GetConfigFilePath(relPath string) (string, error) {
+	path, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(path, relPath), nil
+}
 
 // InitializeInertiaProject creates the inertia config folder and
 // returns an error if we're not in a git project.
@@ -33,7 +40,7 @@ func InitializeInertiaProject(version, buildType, buildFilePath string) error {
 // createConfigFile returns an error if the config directory
 // already exists (the project is already initialized).
 func createConfigFile(version, buildType, buildFilePath string) error {
-	configFilePath, err := GetConfigFilePath()
+	configFilePath, err := GetConfigFilePath("inertia.toml")
 	if err != nil {
 		return err
 	}
@@ -65,8 +72,8 @@ func createConfigFile(version, buildType, buildFilePath string) error {
 
 // GetProjectConfigFromDisk returns the current project's configuration.
 // If an .inertia folder is not found, it returns an error.
-func GetProjectConfigFromDisk() (*cfg.Config, string, error) {
-	configFilePath, err := GetConfigFilePath()
+func GetProjectConfigFromDisk(relPath string) (*cfg.Config, string, error) {
+	configFilePath, err := GetConfigFilePath(relPath)
 	if err != nil {
 		return nil, "", err
 	}
@@ -88,18 +95,9 @@ func GetProjectConfigFromDisk() (*cfg.Config, string, error) {
 	return &cfg, configFilePath, err
 }
 
-// GetConfigFilePath returns the absolute path of the config file.
-func GetConfigFilePath() (string, error) {
-	path, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(path, configFileName), nil
-}
-
 // GetClient returns a local deployment setup
-func GetClient(name string, cmd ...*cobra.Command) (*client.Client, error) {
-	config, _, err := GetProjectConfigFromDisk()
+func GetClient(name, relPath string, cmd ...*cobra.Command) (*client.Client, error) {
+	config, _, err := GetProjectConfigFromDisk(relPath)
 	if err != nil {
 		return nil, err
 	}

--- a/local/storage.go
+++ b/local/storage.go
@@ -11,20 +11,12 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/ubclaunchpad/inertia/cfg"
 	"github.com/ubclaunchpad/inertia/client"
+	"github.com/ubclaunchpad/inertia/common"
 )
-
-// GetConfigFilePath returns the absolute path of the config file.
-func GetConfigFilePath(relPath string) (string, error) {
-	path, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(path, relPath), nil
-}
 
 // InitializeInertiaProject creates the inertia config folder and
 // returns an error if we're not in a git project.
-func InitializeInertiaProject(version, buildType, buildFilePath string) error {
+func InitializeInertiaProject(configPath, version, buildType, buildFilePath string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -34,13 +26,13 @@ func InitializeInertiaProject(version, buildType, buildFilePath string) error {
 		return err
 	}
 
-	return createConfigFile(version, buildType, buildFilePath)
+	return createConfigFile(configPath, version, buildType, buildFilePath)
 }
 
 // createConfigFile returns an error if the config directory
 // already exists (the project is already initialized).
-func createConfigFile(version, buildType, buildFilePath string) error {
-	configFilePath, err := GetConfigFilePath("inertia.toml")
+func createConfigFile(configPath, version, buildType, buildFilePath string) error {
+	configFilePath, err := common.GetFullPath(configPath)
 	if err != nil {
 		return err
 	}
@@ -73,7 +65,7 @@ func createConfigFile(version, buildType, buildFilePath string) error {
 // GetProjectConfigFromDisk returns the current project's configuration.
 // If an .inertia folder is not found, it returns an error.
 func GetProjectConfigFromDisk(relPath string) (*cfg.Config, string, error) {
-	configFilePath, err := GetConfigFilePath(relPath)
+	configFilePath, err := common.GetFullPath(relPath)
 	if err != nil {
 		return nil, "", err
 	}

--- a/local/storage_test.go
+++ b/local/storage_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestInitializeInertiaProjetFail(t *testing.T) {
-	err := InitializeInertiaProject("", "", "")
+	err := InitializeInertiaProject("inertia.toml", "", "", "")
 	assert.NotNil(t, err)
 }
 
@@ -19,11 +19,11 @@ func TestGetConfigFail(t *testing.T) {
 }
 
 func TestConfigCreateAndWriteAndRead(t *testing.T) {
-	err := createConfigFile("test", "dockerfile", "")
+	err := createConfigFile("inertia.toml", "test", "dockerfile", "")
 	assert.Nil(t, err)
 
 	// Already exists
-	err = createConfigFile("test", "dockerfile", "")
+	err = createConfigFile("inertia.toml", "test", "dockerfile", "")
 	assert.NotNil(t, err)
 
 	// Get config and add remotes

--- a/local/storage_test.go
+++ b/local/storage_test.go
@@ -14,7 +14,7 @@ func TestInitializeInertiaProjetFail(t *testing.T) {
 }
 
 func TestGetConfigFail(t *testing.T) {
-	_, _, err := GetProjectConfigFromDisk()
+	_, _, err := GetProjectConfigFromDisk("inertia.toml")
 	assert.NotNil(t, err)
 }
 
@@ -27,7 +27,7 @@ func TestConfigCreateAndWriteAndRead(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// Get config and add remotes
-	config, configPath, err := GetProjectConfigFromDisk()
+	config, configPath, err := GetProjectConfigFromDisk("inertia.toml")
 	assert.Nil(t, err)
 	config.AddRemote(&cfg.RemoteVPS{
 		Name:    "test",
@@ -55,17 +55,17 @@ func TestConfigCreateAndWriteAndRead(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test config read
-	readConfig, _, err := GetProjectConfigFromDisk()
+	readConfig, _, err := GetProjectConfigFromDisk("inertia.toml")
 	assert.Nil(t, err)
 	assert.Equal(t, config.Remotes[0], readConfig.Remotes[0])
 	assert.Equal(t, config.Remotes[1], readConfig.Remotes[1])
 
 	// Test client read
-	client, err := GetClient("test2")
+	client, err := GetClient("test2", "inertia.toml")
 	assert.Nil(t, err)
 	assert.Equal(t, "test2", client.Name)
 	assert.Equal(t, "12343:80801", client.GetIPAndPort())
-	_, err = GetClient("asdf")
+	_, err = GetClient("asdf", "inertia.toml")
 	assert.NotNil(t, err)
 
 	// Test config remove

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ var (
 	Version string
 
 	// ConfigFilePath is the relative path to Inertia's configuration file
-	ConfigFilePath string
+	ConfigFilePath = "inertia.toml"
 )
 
 func getVersion() string {

--- a/main.go
+++ b/main.go
@@ -7,8 +7,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Version is the current build of Inertia
-var Version string
+var (
+	// Version is the current build of Inertia
+	Version string
+
+	// ConfigFilePath is the relative path to Inertia's configuration file
+	ConfigFilePath string
+)
 
 func getVersion() string {
 	if Version == "" {
@@ -36,6 +41,7 @@ Issue tracker: https://github.com/ubclaunchpad/inertia/issues`,
 
 func main() {
 	cobra.EnableCommandSorting = false
+	cmdRoot.PersistentFlags().StringVar(&ConfigFilePath, "config", "inertia.toml", "Specify relative path to Inertia configuration")
 	if err := cmdRoot.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)

--- a/remote.go
+++ b/remote.go
@@ -49,7 +49,7 @@ file. Specify a VPS name.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure project initialized.
-		config, path, err := local.GetProjectConfigFromDisk()
+		config, path, err := local.GetProjectConfigFromDisk(ConfigFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -88,7 +88,7 @@ var cmdListRemotes = &cobra.Command{
 	Long:  `Lists all currently configured remotes.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		verbose, _ := cmd.Flags().GetBool("verbose")
-		config, _, err := local.GetProjectConfigFromDisk()
+		config, _, err := local.GetProjectConfigFromDisk(ConfigFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -109,7 +109,7 @@ var cmdRemoveRemote = &cobra.Command{
 	Long:  `Remove a remote from Inertia's configuration file.`,
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		config, path, err := local.GetProjectConfigFromDisk()
+		config, path, err := local.GetProjectConfigFromDisk(ConfigFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -135,7 +135,7 @@ var cmdShowRemote = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure project initialized.
-		config, _, err := local.GetProjectConfigFromDisk()
+		config, _, err := local.GetProjectConfigFromDisk(ConfigFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -156,7 +156,7 @@ var cmdSetRemoteProperty = &cobra.Command{
 	Args:  cobra.MinimumNArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure project initialized.
-		config, path, err := local.GetProjectConfigFromDisk()
+		config, path, err := local.GetProjectConfigFromDisk(ConfigFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/users.go
+++ b/users.go
@@ -31,7 +31,7 @@ Use the --admin flag to create an admin user.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, cmd)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -80,7 +80,7 @@ deployment from the web app.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, cmd)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -117,7 +117,7 @@ from the web app.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, cmd)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -151,7 +151,7 @@ var cmdDeploymentListUsers = &cobra.Command{
 	Long:  `List all users with access to Inertia Web on your remote.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, cmd)
+		deployment, err := local.GetClient(remoteName, ConfigFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #273

---

## :construction_worker: Changes

- New `--config` flag + a hack to parse it during `init()` to specify config path
- Updated package `local` functions to take path as argument

## :flashlight: Testing Instructions

Make two inertia configs:

```
inertia1.toml
inertia2.toml
```

set them up, then:

```
make inertia
inertia --config inertia1.toml remote ls
inertia --config inertia2.toml remote ls
```