### PR TITLE
Add commit, merge, and branch guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,31 @@ All pull requests should be connected to one or more issues. Please try to fill 
 
 At the very least, all pull requests need to pass our Travis builds and receive an approval from a reviewer. Please include tests whenever possible.
 
-Read on for a comprehensive guide on how to get started with Inertia's codebase!
+See the [Development Tips](#development-tips) section to get started with the codebase!
+
+## Guidelines
+
+### Commits
+
+When writing a commit message, consider how useful it might be to someone reading it - can a reader tell *why* you made your changes based on your commit message? Try to avoid messages like `fix` or `wip` - for example, write `Fix x` or `Scaffold y`.
+
+Formatting-wise, just follow basic Git commit message conventions - capitalize subject line, use the imperative mood, and so on. See [this guide](https://chris.beams.io/posts/git-commit/#seven-rules) for an introduction on writing good Git commit messages.
+
+### Merging Pull Requests
+
+Small, nuclear changes should be squashed - on our ZenHub board, this usually means tickets with 3 or fewer Epic Points. Pull requests with lots of "mistake" commits (`add back accidentally deleted file` or `wip wip`) should be squashed as well. 
+
+Larger pull requests, given the commits are reasonable, should be merged with a standard `merge` to preserve history. On our ZenHub board, this usually means tickets with 8 or more Epic Points.
+
+### Branch Naming
+
+Branches should be named to refer to the component of Inertia the changes pertain to, as well as a related ticket. The component should correspond to [Labels](https://github.com/ubclaunchpad/inertia/labels) that begin with `area: ...`. The format ideally goes:
+
+```
+[area]/#[ticket]-[summary]
+```
+
+For example, [Issue #261](https://github.com/ubclaunchpad/inertia/issues/261) has the label `area: client` - in that case, the branch name should be `client/#261-ec2-provisioning`. If there are multiple `area` labels, just choose the most relevant one.
 
 # Development Tips
 


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #285

---

## :construction_worker: Changes

slack post:

> about commits and PR's going forward - as we approach 1000 commits (lol) we might want to start being a bit more strict on commits and organization. my thoughts right now:
> * `squash` (join all commits in a PR into one commit) small, nuclear changes - probably stuff lt/eq 3 zenhub story points, as well as PRs with lots of "mistake" commits (`add back accidentally deleted file` or `wip wip` commits for example (I've kind of already started this with PRs with the `merge: squash` label)
> * do standard merge commits for bigger PRs (gt/eq 8 zenhub story points) to keep more granular history, since there might be multiple "steps" to these PRs and it's kinda useless to squash a PR that encompasses 20+ files into a single commit
>
> As for branching, instead of `[name]/#[ticket]-[summary]` (ie `anna/#197-favicon`), do `[area]/#[ticket]-[summary]` so that it's a bit more clear what component of inertia the branch is devoted to. These `area`s should correspond to the `area: ...` label (https://github.com/ubclaunchpad/inertia/labels) associated with your ticket. If it encompasses multiple labels, just choose one :stuck_out_tongue:
>
> For example, #187 has label `area: daemon` - so my corresponding branch for that PR is `daemon/#187-authentication`
> this way it's easier to tell a glance what component of Inertia to expect that branch to have made changes in, which will probably help as Inertia continues to grow
