### PR TITLE
Replace stdout prints with FPrint to set writers

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -47,6 +48,7 @@ func getMockClient(ts *httptest.Server) *Client {
 
 	return &Client{
 		RemoteVPS: mockRemote,
+		out:       os.Stdout,
 		project:   "test_project",
 	}
 }
@@ -66,12 +68,14 @@ func getIntegrationClient(mockRunner *mockSSHRunner) *Client {
 		return &Client{
 			version:   "test",
 			RemoteVPS: remote,
+			out:       os.Stdout,
 			sshRunner: mockRunner,
 		}
 	}
 	return &Client{
 		version:   "test",
 		RemoteVPS: remote,
+		out:       os.Stdout,
 		sshRunner: NewSSHRunner(remote),
 	}
 }

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -23,7 +23,7 @@ variables are applied to all deployed containers.`,
 	Args: cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, configFilePath, cmd)
+		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -55,7 +55,7 @@ and persistent environment storage.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, configFilePath, cmd)
+		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -79,7 +79,7 @@ var cmdDeploymentEnvList = &cobra.Command{
 	Short: "List currently set and saved environment variables",
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, configFilePath, cmd)
+		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -66,9 +66,9 @@ var cmdProvisionECS = &cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
-			prov, err = provision.NewEC2Provisioner(id, key)
+			prov, err = provision.NewEC2Provisioner(id, key, os.Stdout)
 		} else {
-			prov, err = provision.NewEC2ProvisionerFromEnv()
+			prov, err = provision.NewEC2ProvisionerFromEnv(os.Stdout)
 		}
 		if err != nil {
 			log.Fatal(err)
@@ -137,7 +137,7 @@ var cmdProvisionECS = &cobra.Command{
 		config.Write(path)
 
 		// Create inertia client
-		inertia, found := client.NewClient(args[0], config)
+		inertia, found := client.NewClient(args[0], config, os.Stdout)
 		if !found {
 			log.Fatal("vps setup did not complete properly")
 		}

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -31,7 +31,7 @@ Use the --admin flag to create an admin user.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, configFilePath, cmd)
+		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -80,7 +80,7 @@ deployment from the web app.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, configFilePath, cmd)
+		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -117,7 +117,7 @@ from the web app.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, configFilePath, cmd)
+		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -151,7 +151,7 @@ var cmdDeploymentListUsers = &cobra.Command{
 	Long:  `List all users with access to Inertia Web on your remote.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
-		deployment, err := local.GetClient(remoteName, configFilePath, cmd)
+		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/common/util.go
+++ b/common/util.go
@@ -10,6 +10,13 @@ import (
 	"time"
 )
 
+// DevNull writes to null, since a nil io.Writer will break shit
+type DevNull struct{}
+
+func (dn DevNull) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
 // GetFullPath returns the absolute path of the config file.
 func GetFullPath(relPath string) (string, error) {
 	path, err := os.Getwd()

--- a/local/storage_test.go
+++ b/local/storage_test.go
@@ -63,11 +63,11 @@ func TestConfigCreateAndWriteAndRead(t *testing.T) {
 	assert.Equal(t, config.Remotes["test2"], readConfig.Remotes["test2"])
 
 	// Test client read
-	client, err := GetClient("test2", "inertia.toml")
+	client, _, err := GetClient("test2", "inertia.toml")
 	assert.Nil(t, err)
 	assert.Equal(t, "test2", client.Name)
 	assert.Equal(t, "12343:80801", client.GetIPAndPort())
-	_, err = GetClient("asdf", "inertia.toml")
+	_, _, err = GetClient("asdf", "inertia.toml")
 	assert.NotNil(t, err)
 
 	// Test config remove


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #193

---

## :construction_worker: Changes

No more straight `println` in package `client`. Made some minor refactors to accomodate this, as well as a new `common.DevNull` type (because `nil` pointers break everything)

## :flashlight: Testing Instructions

run the CLI through its paces
