### PR TITLE
Daemon/#133 webhooks

### DIFF
--- a/daemon/inertiad/webhook/github.go
+++ b/daemon/inertiad/webhook/github.go
@@ -20,12 +20,18 @@ type GithubPushEvent struct {
 type GithubPushEventRepository struct {
 	FullName string `json:"full_name"`
 	GitURL   string `json:"clone_url"`
+	SSHURL   string `json:"ssh_url"`
 }
 
 func parseGithubEvent(r *http.Request, event string) (Payload, error) {
-	// TODO: Can switch on different event types here
-	fmt.Printf("Type: %s", event)
-	payload := GithubPushEvent{eventType: event}
+	var payload Payload
+	switch event {
+	case "push":
+		fmt.Println("Push event")
+		payload = GithubPushEvent{eventType: event}
+	default:
+		return nil, errors.New("Unsupported Github event")
+	}
 
 	err := json.NewDecoder(r.Body).Decode(&payload)
 	if err != nil {
@@ -53,4 +59,9 @@ func (g GithubPushEvent) GetRef() string {
 // GetGitURL returns the git clone URL
 func (g GithubPushEvent) GetGitURL() string {
 	return g.Repo.GitURL
+}
+
+// GetSSHURL returns the ssh URL
+func (g GithubPushEvent) GetSSHURL() string {
+	return g.Repo.SSHURL
 }

--- a/daemon/inertiad/webhook/github.go
+++ b/daemon/inertiad/webhook/github.go
@@ -1,0 +1,56 @@
+package webhook
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// GithubPushEvent represents a push to a Github respository
+// see https://developer.github.com/v3/activity/events/types/#pushevent
+type GithubPushEvent struct {
+	eventType string
+	Ref       string                    `json:"ref"`
+	Repo      GithubPushEventRepository `json:"repository"`
+}
+
+// GithubPushEventRepository represents the repository object in a Github PushEvent
+// see https://developer.github.com/v3/activity/events/types/#pushevent
+type GithubPushEventRepository struct {
+	FullName string `json:"full_name"`
+	GitURL   string `json:"clone_url"`
+}
+
+func parseGithubEvent(r *http.Request, event string) (Payload, error) {
+	// TODO: Can switch on different event types here
+	fmt.Printf("Type: %s", event)
+	payload := GithubPushEvent{eventType: event}
+
+	err := json.NewDecoder(r.Body).Decode(&payload)
+	if err != nil {
+		return nil, errors.New("Error decoding body")
+	}
+
+	return payload, nil
+}
+
+// GetEventType returns the event type of the webhook
+func (g GithubPushEvent) GetEventType() string {
+	return g.eventType
+}
+
+// GetRepoName returns the full repo name
+func (g GithubPushEvent) GetRepoName() string {
+	return g.Repo.FullName
+}
+
+// GetRef returns the full ref
+func (g GithubPushEvent) GetRef() string {
+	return g.Ref
+}
+
+// GetGitURL returns the git clone URL
+func (g GithubPushEvent) GetGitURL() string {
+	return g.Repo.GitURL
+}

--- a/daemon/inertiad/webhook/webhook.go
+++ b/daemon/inertiad/webhook/webhook.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-
-	"github.com/ubclaunchpad/inertia/common"
 )
 
 // Payload represents a generic webhook payload
@@ -18,7 +16,8 @@ type Payload interface {
 	GetSSHURL() string
 }
 
-func parse(r *http.Request) (Payload, error) {
+// Parse takes in a webhook request and parses it into one of the supported types
+func Parse(r *http.Request) (Payload, error) {
 	fmt.Println("Parsing webhook...")
 
 	if r.Header.Get("content-type") != "application/json" {
@@ -36,27 +35,15 @@ func parse(r *http.Request) (Payload, error) {
 	gitlabEventHeader := r.Header.Get("x-gitlab-event")
 	if len(gitlabEventHeader) > 0 {
 		fmt.Println("Gitlab webhook received")
-		return nil, nil
+		return nil, errors.New("Unsupported webhook received")
 	}
 
 	// Try Bitbucket
 	userAgent := r.Header.Get("user-agent")
 	if strings.Contains(userAgent, "Bitbucket") {
 		fmt.Println("Bitbucket webhook received")
-		return nil, nil
+		return nil, errors.New("Unsupported webhook received")
 	}
 
 	return nil, errors.New("Unsupported webhook received")
-}
-
-// Handler receives a webhook and parses it into one of the supported types
-func Handler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, common.MsgDaemonOK)
-	payload, err := parse(r)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	fmt.Println(payload)
 }

--- a/daemon/inertiad/webhook/webhook.go
+++ b/daemon/inertiad/webhook/webhook.go
@@ -1,0 +1,50 @@
+package webhook
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/ubclaunchpad/inertia/common"
+)
+
+func parse(r *http.Request) (string, error) {
+	fmt.Println("Parsing webhook...")
+
+	if r.Header.Get("content-type") != "application/json" {
+		return "", errors.New("Content-Type must be JSON")
+	}
+
+	// Try Github
+	githubEventHeader := r.Header.Get("x-github-event")
+	if len(githubEventHeader) > 0 {
+		return "Github webhook received", nil
+	}
+
+	// Try Gitlab
+	gitlabEventHeader := r.Header.Get("x-gitlab-event")
+	if len(gitlabEventHeader) > 0 {
+		return "Gitlab webhook received", nil
+	}
+
+	// Try Bitbucket
+	userAgent := r.Header.Get("user-agent")
+	if strings.Contains(userAgent, "BitBucket") {
+		return "Bitbucket webhook received", nil
+	}
+
+	return "", errors.New("Unsupported webhook received")
+}
+
+// Handler receives a webhook and parses it into one of the supported types
+func Handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, common.MsgDaemonOK)
+	payload, err := parse(r)
+	if err != nil {
+		println(err)
+		return
+	}
+
+	println(payload)
+}

--- a/daemon/inertiad/webhook/webhook.go
+++ b/daemon/inertiad/webhook/webhook.go
@@ -15,6 +15,7 @@ type Payload interface {
 	GetRepoName() string
 	GetRef() string
 	GetGitURL() string
+	GetSSHURL() string
 }
 
 func parse(r *http.Request) (Payload, error) {
@@ -28,7 +29,7 @@ func parse(r *http.Request) (Payload, error) {
 	githubEventHeader := r.Header.Get("x-github-event")
 	if len(githubEventHeader) > 0 {
 		fmt.Println("Github webhook received")
-		return nil, nil
+		return parseGithubEvent(r, githubEventHeader)
 	}
 
 	// Try Gitlab

--- a/daemon/inertiad/webhook/webhook.go
+++ b/daemon/inertiad/webhook/webhook.go
@@ -9,32 +9,43 @@ import (
 	"github.com/ubclaunchpad/inertia/common"
 )
 
-func parse(r *http.Request) (string, error) {
+// Payload represents a generic webhook payload
+type Payload interface {
+	GetEventType() string
+	GetRepoName() string
+	GetRef() string
+	GetGitURL() string
+}
+
+func parse(r *http.Request) (Payload, error) {
 	fmt.Println("Parsing webhook...")
 
 	if r.Header.Get("content-type") != "application/json" {
-		return "", errors.New("Content-Type must be JSON")
+		return nil, errors.New("Content-Type must be JSON")
 	}
 
 	// Try Github
 	githubEventHeader := r.Header.Get("x-github-event")
 	if len(githubEventHeader) > 0 {
-		return "Github webhook received", nil
+		fmt.Println("Github webhook received")
+		return nil, nil
 	}
 
 	// Try Gitlab
 	gitlabEventHeader := r.Header.Get("x-gitlab-event")
 	if len(gitlabEventHeader) > 0 {
-		return "Gitlab webhook received", nil
+		fmt.Println("Gitlab webhook received")
+		return nil, nil
 	}
 
 	// Try Bitbucket
 	userAgent := r.Header.Get("user-agent")
-	if strings.Contains(userAgent, "BitBucket") {
-		return "Bitbucket webhook received", nil
+	if strings.Contains(userAgent, "Bitbucket") {
+		fmt.Println("Bitbucket webhook received")
+		return nil, nil
 	}
 
-	return "", errors.New("Unsupported webhook received")
+	return nil, errors.New("Unsupported webhook received")
 }
 
 // Handler receives a webhook and parses it into one of the supported types
@@ -42,9 +53,9 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, common.MsgDaemonOK)
 	payload, err := parse(r)
 	if err != nil {
-		println(err)
+		fmt.Println(err)
 		return
 	}
 
-	println(payload)
+	fmt.Println(payload)
 }


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #133 

---

## :construction_worker: Changes

A new webhook package. It exports an interface and one method for parsing a webhook request. The Parse method will detect the git host, validate it, and parse it into the correct struct. Need some feedback on what other information in the webhook is useful. Any other feedback is greatly appreciated!

Usage:
```
payload := webhook.Parse(req)
..
..
println(payload.GetRef())
println(payload.GetGitURL())
...
...
switch event := payload.GetEventType() {
...
...
```

## :flashlight: Testing Instructions

make test
At the moment, webhook types must be `content-type: application/json`. It appears that only Github allows the form-encoded option, so down the line, we can add support for this too!
