### PR TITLE
Add README files to local/ and provision/

### DIFF
--- a/local/README.md
+++ b/local/README.md
@@ -1,0 +1,5 @@
+# Local
+
+[![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](https://godoc.org/github.com/ubclaunchpad/inertia/local)
+
+This package contains utility functions that interact with a local git repository and creates config files for Inertia upon first-time setup.

--- a/provision/README.md
+++ b/provision/README.md
@@ -1,0 +1,5 @@
+# Provision
+
+[![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](https://godoc.org/github.com/ubclaunchpad/inertia/provision)
+
+This package contains API calls to the [Amazon Elastic Compute Cloud](https://aws.amazon.com/ec2/) web service.


### PR DESCRIPTION
Hey @bobheadxi,

These additions are for an assignment in my technical writing course, tasked with improving the docs in public repos. A higher grade will be rewarded if PRs are approved. Please let me know if there are any issues with this PR that could be rectified, or any further additions I can help make, in order to gain an approval.

Thanks,
-Correy

## :construction_worker: Changes

- Add README.md files for `local/` and `provision/`