### PR TITLE
Clean up tooltips for consistency

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -82,7 +82,7 @@ to succeed.`,
 var cmdReset = &cobra.Command{
 	Use:   "reset",
 	Short: "Remove inertia configuration from this repository",
-	Long:  `Reset removes the Inertia configuration files pertaining to this project.`,
+	Long:  `Removes Inertia configuration files pertaining to this project.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		println("WARNING: This will remove your current Inertia configuration")
 		println("and is irreversible. Continue? (y/n)")
@@ -106,7 +106,7 @@ var cmdReset = &cobra.Command{
 var cmdSetConfigProperty = &cobra.Command{
 	Use:   "set [property] [value]",
 	Short: "Update a property of your Inertia project configuration",
-	Long:  `Update a property of your Inertia project configuration and save it to inertia.toml.`,
+	Long:  `Updates a property of your Inertia project configuration and save it to inertia.toml.`,
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure project initialized.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -23,8 +23,8 @@ func init() {
 
 var cmdInit = &cobra.Command{
 	Use:   "init",
-	Short: "Initialize an inertia project in this repository",
-	Long: `Initialize an inertia project in this GitHub repository.
+	Short: "Initialize an Inertia project in this repository",
+	Long: `Initializes an Inertia project in this GitHub repository.
 There must be a local git repository in order for initialization
 to succeed.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -13,12 +13,12 @@ import (
 
 // Initialize "inertia" commands regarding basic configuration
 func init() {
-	Root.PersistentFlags().StringVar(&configFilePath, "config", "inertia.toml", "Specify relative path to Inertia configuration")
+	Root.PersistentFlags().StringVar(&configFilePath, "config", "inertia.toml", "specify relative path to Inertia configuration")
 	Root.AddCommand(cmdInit)
 	Root.AddCommand(cmdReset)
 	Root.AddCommand(cmdSetConfigProperty)
 
-	cmdInit.Flags().String("version", Root.Version, "Specify Inertia daemon version to use")
+	cmdInit.Flags().String("version", Root.Version, "specify Inertia daemon version to use")
 }
 
 var cmdInit = &cobra.Command{
@@ -81,9 +81,8 @@ to succeed.`,
 
 var cmdReset = &cobra.Command{
 	Use:   "reset",
-	Short: "Reset the Inertia project in this repository.",
-	Long: `Reset removes the existing Inertia configuration from
-	this repository.`,
+	Short: "Remove inertia configuration from this repository",
+	Long:  `Reset removes the Inertia configuration files pertaining to this project.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		println("WARNING: This will remove your current Inertia configuration")
 		println("and is irreversible. Continue? (y/n)")
@@ -105,9 +104,9 @@ var cmdReset = &cobra.Command{
 }
 
 var cmdSetConfigProperty = &cobra.Command{
-	Use:   "set [PROPERTY] [VALUE]",
-	Short: "Set configuration property of the project",
-	Long:  `Set configuration property of the project. This will modify local toml file.`,
+	Use:   "set [property] [value]",
+	Short: "Update a property of your Inertia project configuration",
+	Long:  `Update a property of your Inertia project configuration and save it to inertia.toml.`,
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure project initialized.

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -51,25 +51,23 @@ func init() {
 	// deployment commands.
 	for _, remote := range config.Remotes {
 		cmd := &cobra.Command{
-			Use:    remote.Name + " [COMMAND]",
+			Use:    remote.Name + " [command]",
 			Hidden: true,
 			Short:  "Configure deployment to " + remote.Name,
 			Long: `Manage deployment on specified remote.
 
 Requires:
-1. an Inertia daemon running on your remote - use 'inertia [REMOTE] init'
-   to set one up.
-2. a deploy key to be registered for the daemon with your GitHub repository.
+1. an Inertia daemon running on your remote - use 'inertia [REMOTE] init' to get it running.
+2. a deploy key to be registered within your remote repository for the daemon to use.
 
-Continuous deployment requires a webhook url to registered for the daemon
-with your GitHub repository.
+Continuous deployment requires the daemon's webhook address to be registered in your remtoe repository.
 
-Run 'inertia [REMOTE] init' to gather this information.`,
+Run 'inertia [remote] init' to gather this information.`,
 		}
 
 		// Deep copy and attach each deployment command.
 		up := deepCopy(cmdDeploymentUp)
-		up.Flags().String("type", "", "Specify a build method for your project")
+		up.Flags().String("type", "", "specify a build method for your project")
 		cmd.AddCommand(up)
 
 		cmd.AddCommand(deepCopy(cmdDeploymentDown))
@@ -79,7 +77,7 @@ Run 'inertia [REMOTE] init' to gather this information.`,
 
 		user := deepCopy(cmdDeploymentUser)
 		adduser := deepCopy(cmdDeploymentAddUser)
-		adduser.Flags().Bool("admin", false, "Create an admin user")
+		adduser.Flags().Bool("admin", false, "create a user with administrator permissions")
 		user.AddCommand(adduser)
 		user.AddCommand(deepCopy(cmdDeploymentRemoveUser))
 		user.AddCommand(deepCopy(cmdDeploymentResetUsers))
@@ -89,13 +87,13 @@ Run 'inertia [REMOTE] init' to gather this information.`,
 		cmd.AddCommand(deepCopy(cmdDeploymentSSH))
 
 		send := deepCopy(cmdDeploymentSendFile)
-		send.Flags().StringP("dest", "d", "", "Path relative from project root to send file to")
-		send.Flags().StringP("permissions", "p", "0655", "Permissions settings for file")
+		send.Flags().StringP("dest", "d", "", "path relative from project root to send file to")
+		send.Flags().StringP("permissions", "p", "0655", "permissions settings to create file with")
 		cmd.AddCommand(send)
 
 		env := deepCopy(cmdDeploymentEnv)
 		setenv := deepCopy(cmdDeploymentEnvSet)
-		setenv.Flags().BoolP("encrypt", "e", false, "Encrypt variable when stored")
+		setenv.Flags().BoolP("encrypt", "e", false, "encrypt variable when stored")
 		env.AddCommand(setenv)
 		env.AddCommand(deepCopy(cmdDeploymentEnvRemove))
 		env.AddCommand(deepCopy(cmdDeploymentEnvList))
@@ -110,12 +108,12 @@ Run 'inertia [REMOTE] init' to gather this information.`,
 		// Attach a "short" option on all commands
 		cmd.PersistentFlags().BoolP(
 			"short", "s", false,
-			"Don't stream output from command",
+			"don't stream output from command",
 		)
 		// Attach "secure" option on all commands to enable SSL verification
 		cmd.PersistentFlags().Bool(
 			"verify-ssl", false,
-			"Verify SSL communications - requires a signed SSL certificate.",
+			"verify SSL communications - requires a signed SSL certificate",
 		)
 		Root.AddCommand(cmd)
 	}
@@ -124,9 +122,9 @@ Run 'inertia [REMOTE] init' to gather this information.`,
 var cmdDeploymentUp = &cobra.Command{
 	Use:   "up",
 	Short: "Bring project online on remote",
-	Long: `Bring project online on remote.
-	This will run 'docker-compose up --build'. Requires the Inertia daemon
-	to be active on your remote - do this by running 'inertia [REMOTE] init'`,
+	Long: `Build and deploy your project on your remote.
+
+This requires an Inertia daemon to be active on your remote - do this by running 'inertia [remote] init'`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
 		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
@@ -188,9 +186,9 @@ var cmdDeploymentUp = &cobra.Command{
 var cmdDeploymentDown = &cobra.Command{
 	Use:   "down",
 	Short: "Bring project offline on remote",
-	Long: `Bring project offline on remote.
-	This will kill all active project containers on your remote.
-	Requires project to be online - do this by running 'inertia [REMOTE] up`,
+	Long: `Stops your project on your remote. This will kill all active project containers on your remote.
+
+Requires project to be online - do this by running 'inertia [remote] up`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
 		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
@@ -224,10 +222,9 @@ var cmdDeploymentDown = &cobra.Command{
 
 var cmdDeploymentStatus = &cobra.Command{
 	Use:   "status",
-	Short: "Print the status of deployment on remote",
-	Long: `Print the status of deployment on remote.
-	Requires the Inertia daemon to be active on your remote - do this by 
-	running 'inertia [REMOTE] up'`,
+	Short: "Print the status of the deployment on this remote",
+	Long: `Prints the status of the deployment on this remote.
+Requires the Inertia daemon to be active on your remote - do this by running 'inertia [remote] up'`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
 		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
@@ -269,12 +266,13 @@ var cmdDeploymentStatus = &cobra.Command{
 }
 
 var cmdDeploymentLogs = &cobra.Command{
-	Use:   "logs",
-	Short: "Access logs of your VPS",
-	Long: `Access logs of containers of your VPS. Argument 'docker-compose'
-	will retrieve logs of the docker-compose build. The additional argument can 
-	also be used to access logs of specific containers - use  'inertia [REMOTE] 
-	status' to see what containers are accessible.`,
+	Use:   "logs [container]",
+	Short: "Access logs of containers on your remote host",
+	Long: `Access logs of containers on your remote host. 
+	
+By default, this command retrieves Inertia daemon logs, but you can provide an 
+argument that specifies the name of the container you wish to retrieve logs for. 
+Use 'inertia [remote] status' to see which containers are active.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
 		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
@@ -334,7 +332,7 @@ var cmdDeploymentLogs = &cobra.Command{
 var cmdDeploymentPrune = &cobra.Command{
 	Use:   "prune",
 	Short: "Prune Docker assets and images on your remote",
-	Long:  `Prunes Docker assets and images from your remote to save storage space.`,
+	Long:  `Prunes Docker assets and images from your remote to free up storage space.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
 		inertia, _, err := local.GetClient(remoteName, configFilePath, cmd)
@@ -359,7 +357,7 @@ var cmdDeploymentPrune = &cobra.Command{
 var cmdDeploymentSSH = &cobra.Command{
 	Use:   "ssh",
 	Short: "Start an interactive SSH session",
-	Long:  `Starts up an interact SSH session with your remote.`,
+	Long:  `Starts an interact SSH session with your remote.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
 		deployment, _, err := local.GetClient(remoteName, configFilePath)
@@ -375,11 +373,10 @@ var cmdDeploymentSSH = &cobra.Command{
 }
 
 var cmdDeploymentSendFile = &cobra.Command{
-	Use:   "send",
+	Use:   "send [filepath]",
 	Short: "Send a file to your Inertia deployment",
-	Long: `Send a file, such as a configuration or .env file, to your Inertia
-deployment. Provide a relative path to your file.`,
-	Args: cobra.ExactArgs(1),
+	Long:  `Send a file, such as a configuration or .env file, to your Inertia deployment.`,
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
 		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
@@ -429,13 +426,16 @@ deployment. Provide a relative path to your file.`,
 
 var cmdDeploymentInit = &cobra.Command{
 	Use:   "init",
-	Short: "Initialize the VPS for continuous deployment",
-	Long: `Initialize the VPS for continuous deployment.
-This sets up everything you might need and brings the Inertia daemon
-online on your remote.
-A URL will be provided to direct GitHub webhooks to, the daemon will
-request access to the repository via a public key, and will listen
-for updates to this repository's remote master branch.`,
+	Short: "Initialize remote host for deployment",
+	Long: `Initialize remote host for deployment.
+This command sets up your remote host and brings an Inertia daemon online on your remote.
+
+Upon successful setup, you will be provided with:
+ - a deploy key
+ - a webhook URL
+
+The deploy key is required for the daemon to access your repository, and the
+webhook URL enables continuous deployment as your repository is updated.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
 		cli, write, err := local.GetClient(remoteName, configFilePath, cmd)
@@ -460,10 +460,8 @@ var cmdDeploymentReset = &cobra.Command{
 	Use:   "reset",
 	Short: "Reset the project on your remote",
 	Long: `Reset the project on your remote.
-On this remote, this kills all active containers and clears the project
-directory, allowing you to assign a different Inertia project to this
-remote. Requires Inertia daemon to be active on your remote - do this by
-running 'inertia [REMOTE] init'`,
+On this remote, this kills all active containers and clears the project directory, 
+allowing you to assign a different Inertia project to this remote.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
 		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
@@ -494,9 +492,9 @@ running 'inertia [REMOTE] init'`,
 
 var cmdDeploymentRemove = &cobra.Command{
 	Use:   "remove",
-	Short: "Remove Inertia and shutdown the daemon in the remote VPS",
-	Long: `Remove Inertia directory (~/inertia) and takes down the
-	daemon image from the VPS.`,
+	Short: "Shut down Inertia and remove Inertia assets from remote host",
+	Long: `Shuts down and removes the Inertia daemon, and removes the Inertia 
+directory (~/inertia) from your remote host.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		println("WARNING: This will remove Inertia from the remote")
 		println("as well as take the daemon and is irreversible. Continue? (y/n)")

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -60,7 +60,7 @@ Requires:
 1. an Inertia daemon running on your remote - use 'inertia [remote] init' to get it running.
 2. a deploy key to be registered within your remote repository for the daemon to use.
 
-Continuous deployment requires the daemon's webhook address to be registered in your remtoe repository.
+Continuous deployment requires the daemon's webhook address to be registered in your remote repository.
 
 Run 'inertia [remote] init' to gather this information.`,
 		}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -30,7 +30,7 @@ func parseConfigArg() {
 	}
 }
 
-// Initialize "inertia [REMOTE] [COMMAND]" commands
+// Initialize "inertia [remote] [cmd]" commands
 func init() {
 	// This is the only place configuration is read every time an `inertia`
 	// command is run - check version here.
@@ -57,7 +57,7 @@ func init() {
 			Long: `Manage deployment on specified remote.
 
 Requires:
-1. an Inertia daemon running on your remote - use 'inertia [REMOTE] init' to get it running.
+1. an Inertia daemon running on your remote - use 'inertia [remote] init' to get it running.
 2. a deploy key to be registered within your remote repository for the daemon to use.
 
 Continuous deployment requires the daemon's webhook address to be registered in your remtoe repository.

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -54,7 +54,7 @@ func init() {
 			Use:    remote.Name + " [command]",
 			Hidden: true,
 			Short:  "Configure deployment to " + remote.Name,
-			Long: `Manage deployment on specified remote.
+			Long: `Manages deployment on specified remote.
 
 Requires:
 1. an Inertia daemon running on your remote - use 'inertia [remote] init' to get it running.
@@ -122,7 +122,7 @@ Run 'inertia [remote] init' to gather this information.`,
 var cmdDeploymentUp = &cobra.Command{
 	Use:   "up",
 	Short: "Bring project online on remote",
-	Long: `Build and deploy your project on your remote.
+	Long: `Builds and deploy your project on your remote.
 
 This requires an Inertia daemon to be active on your remote - do this by running 'inertia [remote] init'`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -268,7 +268,7 @@ Requires the Inertia daemon to be active on your remote - do this by running 'in
 var cmdDeploymentLogs = &cobra.Command{
 	Use:   "logs [container]",
 	Short: "Access logs of containers on your remote host",
-	Long: `Access logs of containers on your remote host. 
+	Long: `Accesses logs of containers on your remote host. 
 	
 By default, this command retrieves Inertia daemon logs, but you can provide an 
 argument that specifies the name of the container you wish to retrieve logs for. 
@@ -375,7 +375,7 @@ var cmdDeploymentSSH = &cobra.Command{
 var cmdDeploymentSendFile = &cobra.Command{
 	Use:   "send [filepath]",
 	Short: "Send a file to your Inertia deployment",
-	Long:  `Send a file, such as a configuration or .env file, to your Inertia deployment.`,
+	Long:  `Sends a file, such as a configuration or .env file, to your Inertia deployment.`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Use, " ")[0]
@@ -427,7 +427,7 @@ var cmdDeploymentSendFile = &cobra.Command{
 var cmdDeploymentInit = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize remote host for deployment",
-	Long: `Initialize remote host for deployment.
+	Long: `Initializes this remote host for deployment.
 This command sets up your remote host and brings an Inertia daemon online on your remote.
 
 Upon successful setup, you will be provided with:
@@ -459,7 +459,7 @@ webhook URL enables continuous deployment as your repository is updated.`,
 var cmdDeploymentReset = &cobra.Command{
 	Use:   "reset",
 	Short: "Reset the project on your remote",
-	Long: `Reset the project on your remote.
+	Long: `Resets the project on your remote.
 On this remote, this kills all active containers and clears the project directory, 
 allowing you to assign a different Inertia project to this remote.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -13,7 +13,7 @@ import (
 var cmdDeploymentEnv = &cobra.Command{
 	Use:   "env",
 	Short: "Manage environment variables on your remote",
-	Long: `Manage environment variables on your remote through Inertia. 
+	Long: `Manages environment variables on your remote through Inertia. 
 	
 Configured variables can be encrypted or stored in plain text, and are applied to 
 all project containers on startup.`,
@@ -22,7 +22,7 @@ all project containers on startup.`,
 var cmdDeploymentEnvSet = &cobra.Command{
 	Use:   "set [name] [value]",
 	Short: "Set an environment variable on your remote",
-	Long: `Set a persistent environment variable on your remote. Set environment
+	Long: `Sets a persistent environment variable on your remote. Set environment
 variables are applied to all deployed containers.`,
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -54,7 +54,7 @@ variables are applied to all deployed containers.`,
 var cmdDeploymentEnvRemove = &cobra.Command{
 	Use:   "rm [name]",
 	Short: "Remove an environment variable from your remote",
-	Long: `Remove the specified environment variable from deployed containers
+	Long: `Removes the specified environment variable from deployed containers
 and persistent environment storage.`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -13,10 +13,14 @@ import (
 var cmdDeploymentEnv = &cobra.Command{
 	Use:   "env",
 	Short: "Manage environment variables on your remote",
+	Long: `Manage environment variables on your remote through Inertia. 
+	
+Configured variables can be encrypted or stored in plain text, and are applied to 
+all project containers on startup.`,
 }
 
 var cmdDeploymentEnvSet = &cobra.Command{
-	Use:   "set [NAME] [VALUE]",
+	Use:   "set [name] [value]",
 	Short: "Set an environment variable on your remote",
 	Long: `Set a persistent environment variable on your remote. Set environment
 variables are applied to all deployed containers.`,
@@ -48,7 +52,7 @@ variables are applied to all deployed containers.`,
 }
 
 var cmdDeploymentEnvRemove = &cobra.Command{
-	Use:   "rm [NAME]",
+	Use:   "rm [name]",
 	Short: "Remove an environment variable from your remote",
 	Long: `Remove the specified environment variable from deployed containers
 and persistent environment storage.`,
@@ -77,6 +81,8 @@ and persistent environment storage.`,
 var cmdDeploymentEnvList = &cobra.Command{
 	Use:   "ls",
 	Short: "List currently set and saved environment variables",
+	Long: `Lists currently set and saved environment variables. The values of encrypted
+variables are not be decrypted.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
 		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -15,32 +15,39 @@ import (
 // Initialize "inertia" commands regarding basic configuration
 func init() {
 	cmdProvisionECS.Flags().StringP(
-		"type", "t", "t2.micro", "The ec2 instance type to instantiate",
+		"type", "t", "t2.micro", "ec2 instance type to instantiate",
 	)
 	cmdProvisionECS.Flags().StringP(
-		"user", "u", "ec2-user", "The ec2 instance type to instantiate",
+		"user", "u", "ec2-user", "ec2 instance user to execute commands as",
 	)
 	cmdProvisionECS.Flags().Bool(
-		"from-env", false, "Load ec2 credentials from environment - requires AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY to be set.",
+		"from-env", false, "load ec2 credentials from environment - requires AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY to be set",
 	)
 	cmdProvision.AddCommand(cmdProvisionECS)
-	cmdProvision.PersistentFlags().StringP("daemon-port", "d", "4303", "Daemon port")
-	cmdProvision.PersistentFlags().StringArrayP("ports", "p", []string{}, "Ports your project uses")
+	cmdProvision.PersistentFlags().StringP("daemon-port", "d", "4303", "daemon port")
+	cmdProvision.PersistentFlags().StringArrayP("ports", "p", []string{}, "ports your project uses")
 	Root.AddCommand(cmdProvision)
 }
 
 var cmdProvision = &cobra.Command{
 	Use:   "provision",
-	Short: "[BETA] Provision a new VPS setup for Inertia",
-	Long:  `[BETA] Provision a new VPS instance set up for continuous deployment with Inertia.`,
+	Short: "Provision a new remote host to deploy your project on",
+	Long:  `Provisions a new remote host set up for continuous deployment with Inertia.`,
 }
 
 var cmdProvisionECS = &cobra.Command{
 	Use:   "ec2 [name]",
 	Short: "[BETA] Provision a new Amazon EC2 instance",
-	Long: `[BETA] Provision a new Amazon EC2 instance and set it up for continuous deployment
-	with Inertia. Make sure you run this command with the '-p' flag to indicate what ports
-	your project uses, since they must be exposed on your new instance.`,
+	Long: `[BETA] Provisions a new Amazon EC2 instance and sets it up for continuous deployment
+with Inertia. 
+
+Make sure you run this command with the '-p' flag to indicate what ports
+your project uses - for example:
+
+	inertia provision ec2 my_ec2_instance -p 8000
+
+This ensures that your project ports are properly exposed and externally accessible.
+`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure project initialized.

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -27,8 +27,8 @@ func init() {
 var cmdRemote = &cobra.Command{
 	Use:   "remote",
 	Short: "Configure the local settings for a remote host",
-	Long: `This command provides functionality such as adding new remotes, removing remotes,
-and configuring other low level configuration of the VPS. 
+	Long: `Configures local settings for a remote host - add, remove, and list configured
+Inertia remotes.
 
 Requires Inertia to be set up via 'inertia init'.
 
@@ -43,7 +43,7 @@ For example:
 var cmdAddRemote = &cobra.Command{
 	Use:   "add [remote]",
 	Short: "Add a reference to a remote VPS instance",
-	Long: `Add a reference to a remote VPS instance. Requires information about the VPS
+	Long: `Adds a reference to a remote VPS instance. Requires information about the VPS
 including IP address, user and a PEM file. The provided name will be used in other
 Inertia commands.`,
 	Args: cobra.ExactArgs(1),

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -19,33 +19,33 @@ func init() {
 	cmdRemote.AddCommand(cmdShowRemote)
 	cmdRemote.AddCommand(cmdSetRemoteProperty)
 
-	cmdListRemotes.Flags().BoolP("verbose", "v", false, "Verbose output")
-	cmdAddRemote.Flags().StringP("port", "p", "4303", "Daemon port")
-	cmdAddRemote.Flags().StringP("sshPort", "s", "22", "SSH port")
+	cmdListRemotes.Flags().BoolP("verbose", "v", false, "enable verbose output")
+	cmdAddRemote.Flags().StringP("port", "p", "4303", "remote daemon port")
+	cmdAddRemote.Flags().StringP("sshPort", "s", "22", "remote SSH port")
 }
 
 var cmdRemote = &cobra.Command{
 	Use:   "remote",
-	Short: "Configure the local settings for a remote VPS instance",
-	Long: `Remote is a low level command for interacting with this VPS
-over SSH. Provides functionality such as adding new remotes, removing remotes,
-bootstrapping the server for deployment, running install scripts such as
-installing docker, starting the Inertia daemon and other low level configuration
-of the VPS. Must run 'inertia init' in your repository before using.
+	Short: "Configure the local settings for a remote host",
+	Long: `This command provides functionality such as adding new remotes, removing remotes,
+and configuring other low level configuration of the VPS. 
 
-Example:
-inerta remote add gcloud
-inerta gcloud init
-inerta remote status gcloud`,
-	Args: cobra.MinimumNArgs(1),
+Requires Inertia to be set up via 'inertia init'.
+
+For example:
+    inertia init
+    inertia remote add gcloud
+    inertia gcloud init        # set up Inertia
+	inertia gcloud status      # check on status of Inertia daemon
+`,
 }
 
 var cmdAddRemote = &cobra.Command{
-	Use:   "add [REMOTE]",
+	Use:   "add [remote]",
 	Short: "Add a reference to a remote VPS instance",
-	Long: `Add a reference to a remote VPS instance. Requires 
-information about the VPS including IP address, user and a PEM
-file. Specify a VPS name.`,
+	Long: `Add a reference to a remote VPS instance. Requires information about the VPS
+including IP address, user and a PEM file. The provided name will be used in other
+Inertia commands.`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure project initialized.
@@ -105,7 +105,7 @@ var cmdListRemotes = &cobra.Command{
 
 var cmdRemoveRemote = &cobra.Command{
 	Use:   "rm [REMOTE]",
-	Short: "Remove a remote.",
+	Short: "Remove a configured remote",
 	Long:  `Remove a remote from Inertia's configuration file.`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -129,9 +129,9 @@ var cmdRemoveRemote = &cobra.Command{
 }
 
 var cmdShowRemote = &cobra.Command{
-	Use:   "show [REMOTE]",
-	Short: "Show details about remote.",
-	Long:  `Show details about the given remote.`,
+	Use:   "show [remote]",
+	Short: "Show details about a remote",
+	Long:  `Shows details about the given remote.`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure project initialized.
@@ -150,9 +150,9 @@ var cmdShowRemote = &cobra.Command{
 }
 
 var cmdSetRemoteProperty = &cobra.Command{
-	Use:   "set [REMOTE] [PROPERTY] [VALUE]",
-	Short: "Set details about remote.",
-	Long:  `Set details about the given remote.`,
+	Use:   "set [remote] [property] [value]",
+	Short: "Update details about remote",
+	Long:  `Updates the given property of the given remote's configuration.`,
 	Args:  cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure project initialized.

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -104,7 +104,7 @@ var cmdListRemotes = &cobra.Command{
 }
 
 var cmdRemoveRemote = &cobra.Command{
-	Use:   "rm [REMOTE]",
+	Use:   "rm [remote]",
 	Short: "Remove a configured remote",
 	Long:  `Remove a remote from Inertia's configuration file.`,
 	Args:  cobra.ExactArgs(1),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,8 +17,8 @@ Initialization involves preparing a server to run an application, then
 activating a daemon which will continuously update the production server
 with new releases as they become available in the project's repository.
 
-One you have set up a remote with 'inertia remote add [REMOTE]',
-use 'inertia [REMOTE] --help' to see what you can do with your remote.
+One you have set up a remote with 'inertia remote add [remote]', use 
+'inertia [remote] --help' to see what you can do with your remote.
 
 Repository:    https://github.com/ubclaunchpad/inertia/
 Issue tracker: https://github.com/ubclaunchpad/inertia/issues`,

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -20,7 +20,7 @@ var cmdDeploymentUser = &cobra.Command{
 }
 
 var cmdDeploymentAddUser = &cobra.Command{
-	Use:   "add",
+	Use:   "add [user]",
 	Short: "Create a user with access to Inertia Web",
 	Long: `Create a user with access to the Inertia Web application.
 
@@ -71,12 +71,12 @@ Use the --admin flag to create an admin user.`,
 }
 
 var cmdDeploymentRemoveUser = &cobra.Command{
-	Use:   "rm",
-	Short: "Remove a user with access to Inertia Web",
-	Long: `Remove a user with access to the Inertia Web application.
+	Use:   "rm [user]",
+	Short: "Remove a user",
+	Long: `Removes the given user from Inertia's user database.
 
-This user will no longer be able to log in and view or configure the
-deployment from the web app.`,
+This user will no longer be able to log in and view or configure the deployment 
+from the web app.`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
@@ -110,10 +110,9 @@ deployment from the web app.`,
 
 var cmdDeploymentResetUsers = &cobra.Command{
 	Use:   "reset",
-	Short: "Reset user database on your remote.",
-	Long: `Removes all users credentials on your remote. All users will
-no longer be able to log in and view or configure the deployment 
-from the web app.`,
+	Short: "Reset user database on your remote",
+	Long: `Removes all users credentials on your remote. All users will no longer 
+be able to log in and view or configure the deployment from the web app.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
 		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
@@ -147,7 +146,7 @@ from the web app.`,
 var cmdDeploymentListUsers = &cobra.Command{
 	Use:   "ls",
 	Short: "List all users registered on your remote.",
-	Long:  `List all users with access to Inertia Web on your remote.`,
+	Long:  `Lists all users registered in Inertia's user database.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
 		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -22,7 +22,7 @@ var cmdDeploymentUser = &cobra.Command{
 var cmdDeploymentAddUser = &cobra.Command{
 	Use:   "add [user]",
 	Short: "Create a user with access to Inertia Web",
-	Long: `Create a user with access to the Inertia Web application.
+	Long: `Creates a user with access to the Inertia Web application.
 
 This user will be able to log in and view or configure the
 deployment from the web app.

--- a/daemon/inertiad/cmd.go
+++ b/daemon/inertiad/cmd.go
@@ -16,7 +16,7 @@ var runCmd = &cobra.Command{
 	Version: getVersion(),
 	Use:     "run [host] [key path] [ssl directory] [userdb dir]",
 	Short:   "Run the daemon",
-	Long: `Run the daemon on a port, default 4303. Requires
+	Long: `Runs the daemon on a port, default 4303. Requires
 host address as an argument.
 
 Example:
@@ -35,8 +35,7 @@ Example:
 var tokenCmd = &cobra.Command{
 	Use:   "token",
 	Short: "Produce an API token to use with the daemon",
-	Long: `Produce an API token to use with the daemon,
-Created using an RSA private key.`,
+	Long:  `Produces an API token to use with the daemon, created using an RSA private key.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		keyBytes, err := crypto.GetAPIPrivateKey(nil)
 		if err != nil {

--- a/daemon/inertiad/git/error.go
+++ b/daemon/inertiad/git/error.go
@@ -15,7 +15,7 @@ func AuthFailedErr(path ...string) error {
 	}
 	bytes, err := ioutil.ReadFile(keyLoc + ".pub")
 	if err != nil {
-		bytes = []byte(err.Error() + "\nError reading key - try running 'inertia [REMOTE] init' again: ")
+		bytes = []byte(err.Error() + "\nError reading key - try running 'inertia [remote] init' again: ")
 	}
 	return errors.New("Access to project repository rejected; did you forget to add\nInertia's deploy key to your repository settings?\n" + string(bytes))
 }

--- a/daemon/inertiad/project/deployment.go
+++ b/daemon/inertiad/project/deployment.go
@@ -282,7 +282,7 @@ func (d *Deployment) CompareRemotes(remoteURL string) error {
 	}
 	localRemoteURL := common.GetSSHRemoteURL(remotes[0].Config().URLs[0])
 	if localRemoteURL != common.GetSSHRemoteURL(remoteURL) {
-		return errors.New("The given remote URL does not match that of the repository in\nyour remote - try 'inertia [REMOTE] reset'")
+		return errors.New("The given remote URL does not match that of the repository in\nyour remote - try 'inertia [remote] reset'")
 	}
 	return nil
 }

--- a/doc.go
+++ b/doc.go
@@ -21,7 +21,7 @@ flag on any command:
 
 	inertia --help
 	inertia init --help
-	inertia [REMOTE] up --help
+	inertia [remote] up --help
 
 Documentation can also be triggered by simply entering a command without the
 prerequisite arguments or additional commands:
@@ -42,7 +42,7 @@ like:
 The other set of commands are based on a remote VPS configuration, and the
 available commands can be seen by running:
 
-	inertia [REMOTE] --help
+	inertia [remote] --help
 
 In the previous example, the next steps to set up a deployment might be:
 


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #308

---

## :construction_worker: Changes

Some tweaks to the wording, punctuation, casing, etc of the tooltips to better align with Cobra (the CLI library) standards

## :flashlight: Testing Instructions

```bash
make cli
inertia # poke around commands
```
