### PR TITLE
Don't reassign deployment

### DIFF
--- a/daemon/inertiad/reset.go
+++ b/daemon/inertiad/reset.go
@@ -34,7 +34,6 @@ func resetHandler(w http.ResponseWriter, r *http.Request) {
 		logger.WriteErr(err.Error(), http.StatusInternalServerError)
 		return
 	}
-	deployment = nil
 
 	logger.WriteSuccess("Project removed from remote.", http.StatusOK)
 }


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #340

---

## :construction_worker: Changes

Don't point `deployment` to `nil` on reset. Null pointers galore

