### PR TITLE
Recreate env bucket upon deleting

### DIFF
--- a/daemon/inertiad/project/data.go
+++ b/daemon/inertiad/project/data.go
@@ -125,6 +125,10 @@ func (c *DeploymentDataManager) GetEnvVariables(decrypt bool) ([]string, error) 
 
 func (c *DeploymentDataManager) destroy() error {
 	return c.db.Update(func(tx *bolt.Tx) error {
-		return tx.DeleteBucket(envVariableBucket)
+		if err := tx.DeleteBucket(envVariableBucket); err != nil {
+			return err
+		}
+		_, err := tx.CreateBucket(envVariableBucket)
+		return err
 	})
 }

--- a/daemon/inertiad/project/data_test.go
+++ b/daemon/inertiad/project/data_test.go
@@ -62,3 +62,22 @@ func TestDataManager_EnvVariableOperations(t *testing.T) {
 		})
 	}
 }
+
+func TestDataManager_destroy(t *testing.T) {
+	dir := "./test_config"
+	err := os.Mkdir(dir, os.ModePerm)
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	// Instantiate
+	c, err := newDataManager(path.Join(dir, "deployment.db"))
+	assert.Nil(t, err)
+
+	// Reset
+	err = c.destroy()
+	assert.Nil(t, err)
+
+	// Check if bucket is still usable
+	_, err = c.GetEnvVariables(false)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #342

---

## :construction_worker: Changes

`reset` clears the `env` bucket, which is great, but we need to recreate it

