### PR TITLE
Create Client from ENV and negotiate API version from there

### DIFF
--- a/daemon/inertiad/containers/docker.go
+++ b/daemon/inertiad/containers/docker.go
@@ -1,11 +1,18 @@
 package containers
 
-import docker "github.com/docker/docker/client"
+import (
+	"context"
 
-// MaxDockerVersion is the maximum supported API version
-const MaxDockerVersion = "1.37"
+	docker "github.com/docker/docker/client"
+)
 
-// NewDockerClient creates a new Docker Client set to a predefined Docker API
+// NewDockerClient creates a new Docker Client from ENV values and negotiates
+// the correct API version
 func NewDockerClient() (*docker.Client, error) {
-	return docker.NewClientWithOpts(docker.WithVersion(MaxDockerVersion))
+	c, err := docker.NewEnvClient()
+	if err != nil {
+		return nil, err
+	}
+	c.NegotiateAPIVersion(context.Background())
+	return c, nil
 }

--- a/daemon/inertiad/containers/docker_test.go
+++ b/daemon/inertiad/containers/docker_test.go
@@ -1,0 +1,13 @@
+package containers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDockerClient(t *testing.T) {
+	c, err := NewDockerClient()
+	assert.Nil(t, err)
+	assert.NotNil(t, c)
+}


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #343

---

## :construction_worker: Changes

b5f9bd34336f3078f635c873affee6916bdbe403 fixed the version to `1.37`, but then @brian-nguyen ran into incompatibilities straight away. This reverts back to creating client from env, but adds an additional step to hopefully negotiate the correct version.

This should be part of the standard `docker.NewClient` -_-
