### PR TITLE
Dockerfile ports, containerstop fixes, minor updates

### DIFF
--- a/daemon/inertiad/build/builder.go
+++ b/daemon/inertiad/build/builder.go
@@ -90,6 +90,7 @@ func (b *Builder) Build(buildType string, d Config,
 	}
 
 	// Build project
+	reportDeployInit(buildType, d.Name, out)
 	deploy, err := builder(d, cli, out)
 	if err != nil {
 		return func() error { return nil }, err
@@ -152,30 +153,22 @@ func (b *Builder) dockerCompose(d Config, cli *docker.Client,
 	}
 
 	// Start container to build project
-	fmt.Fprintf(out, "Building project %s...\n", d.Name)
-	err = cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{})
-	if err != nil {
+	reportProjectBuildBegin(d.Name, out)
+	if err := containers.StartAndWait(cli, resp.ID, out); err != nil {
 		return nil, err
 	}
-	stop := make(chan struct{})
-	go containers.StreamContainerLogs(cli, resp.ID, out, stop)
-	exitCode, err := containers.Wait(cli, resp.ID, stop)
-	if err != nil {
-		return nil, err
-	}
-	if exitCode != 0 {
-		return nil, fmt.Errorf("Build exited with non-zero status %d", exitCode)
-	}
-	fmt.Fprintf(out, "Build exited with status code %d", exitCode)
+	reportProjectBuildComplete(d.Name, out)
 
 	// @TODO allow configuration
-	dockerComposeRelFilePath := "docker-compose.yml"
-	dockerComposeFilePath := path.Join(
-		getTrueDirectory(d.BuildDirectory), dockerComposeRelFilePath,
+	var (
+		dockerComposeRelFilePath = "docker-compose.yml"
+		dockerComposeFilePath    = path.Join(
+			getTrueDirectory(d.BuildDirectory), dockerComposeRelFilePath,
+		)
 	)
 
 	// Set up docker-compose up
-	fmt.Fprintln(out, "Preparing to start project...")
+	reportProjectContainerCreateBegin(d.Name, out)
 	resp, err = cli.ContainerCreate(
 		ctx, &container.Config{
 			Image:      b.dockerComposeVersion,
@@ -202,20 +195,20 @@ func (b *Builder) dockerCompose(d Config, cli *docker.Client,
 		warnings := strings.Join(resp.Warnings, "\n")
 		return nil, errors.New(warnings)
 	}
+	reportProjectContainerCreateComplete(d.Name, out)
 
-	return func() error { return b.run(ctx, cli, resp.ID, out) }, nil
+	return func() error { return b.run(ctx, cli, d.Name, resp.ID, out) }, nil
 }
 
 // dockerBuild builds project from Dockerfile, and returns a callback function to deploy it
 func (b *Builder) dockerBuild(d Config, cli *docker.Client,
 	out io.Writer) (func() error, error) {
-	fmt.Fprintf(out, "Building Dockerfile project %s...\n", d.Name)
-
 	var (
 		ctx      = context.Background()
 		buildCtx = bytes.NewBuffer(nil)
 	)
 
+	// Create build context
 	if err := buildTar(d.BuildDirectory, buildCtx); err != nil {
 		return nil, err
 	}
@@ -227,6 +220,7 @@ func (b *Builder) dockerBuild(d Config, cli *docker.Client,
 	}
 
 	// Build image
+	reportProjectBuildBegin(d.Name, out)
 	imageName := "inertia-build/" + d.Name
 	buildResp, err := cli.ImageBuild(
 		ctx, buildCtx, types.ImageBuildOptions{
@@ -239,13 +233,12 @@ func (b *Builder) dockerBuild(d Config, cli *docker.Client,
 	if err != nil {
 		return nil, err
 	}
-
-	// Output build progress
 	stop := make(chan struct{})
 	log.FlushRoutine(out, buildResp.Body, stop)
 	close(stop)
 	buildResp.Body.Close()
-	fmt.Fprintf(out, "%s (%s) build has exited\n", imageName, buildResp.OSType)
+	// todo: detect failures
+	reportProjectBuildComplete(d.Name, out)
 
 	// Get image details
 	image, _, err := cli.ImageInspectWithRaw(ctx, imageName)
@@ -258,6 +251,7 @@ func (b *Builder) dockerBuild(d Config, cli *docker.Client,
 	}
 
 	// Create container from image
+	reportProjectContainerCreateBegin(d.Name, out)
 	containerResp, err := cli.ContainerCreate(
 		ctx, &container.Config{
 			Image: imageName,
@@ -276,8 +270,9 @@ func (b *Builder) dockerBuild(d Config, cli *docker.Client,
 		warnings := strings.Join(containerResp.Warnings, "\n")
 		return nil, errors.New(warnings)
 	}
+	reportProjectContainerCreateComplete(d.Name, out)
 
-	return func() error { return b.run(ctx, cli, containerResp.ID, out) }, nil
+	return func() error { return b.run(ctx, cli, d.Name, containerResp.ID, out) }, nil
 }
 
 // herokuishBuild uses the Herokuish tool to use Heroku's official buidpacks
@@ -312,27 +307,15 @@ func (b *Builder) herokuishBuild(d Config, cli *docker.Client,
 	}
 
 	// Start the herokuish container to build project
-	fmt.Fprintf(out, "Building project %s...\n", d.Name)
-	err = cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{})
-	if err != nil {
+	reportProjectBuildBegin(d.Name, out)
+	if err := containers.StartAndWait(cli, resp.ID, out); err != nil {
 		return nil, err
 	}
-
-	// Attach logs and report build progress until container exits
-	stop := make(chan struct{})
-	go containers.StreamContainerLogs(cli, resp.ID, out, stop)
-	exitCode, err := containers.Wait(cli, resp.ID, stop)
-	if err != nil {
-		return nil, err
-	}
-	if exitCode != 0 {
-		return nil, fmt.Errorf("Build exited with non-zero status %d", exitCode)
-	}
-	fmt.Fprintf(out, "Build exited with status code %d", exitCode)
+	reportProjectBuildComplete(d.Name, out)
 
 	// Save build as new image and create a container
 	imgName := "inertia-build/" + d.Name
-	fmt.Fprintln(out, "Saving build...")
+	reportProjectContainerCreateBegin(d.Name, out)
 	_, err = cli.ContainerCommit(ctx, resp.ID, types.ContainerCommitOptions{
 		Reference: imgName,
 	})
@@ -354,13 +337,14 @@ func (b *Builder) herokuishBuild(d Config, cli *docker.Client,
 		warnings := strings.Join(resp.Warnings, "\n")
 		return nil, errors.New(warnings)
 	}
+	reportProjectContainerCreateComplete(d.Name, out)
 
-	return func() error { return b.run(ctx, cli, resp.ID, out) }, nil
+	return func() error { return b.run(ctx, cli, d.Name, resp.ID, out) }, nil
 }
 
 // run starts project and tracks all active project containers and pipes an error
 // to the returned channel if any container exits or errors.
-func (b *Builder) run(ctx context.Context, client *docker.Client, id string, out io.Writer) error {
-	fmt.Fprintln(out, "Starting up project...")
+func (b *Builder) run(ctx context.Context, client *docker.Client, name, id string, out io.Writer) error {
+	reportProjectStartup(name, out)
 	return client.ContainerStart(ctx, id, types.ContainerStartOptions{})
 }

--- a/daemon/inertiad/build/output.go
+++ b/daemon/inertiad/build/output.go
@@ -1,0 +1,30 @@
+package build
+
+import (
+	"fmt"
+	"io"
+)
+
+func reportDeployInit(buildType, name string, out io.Writer) {
+	fmt.Fprintf(out, "Building %s project %s...\n", buildType, name)
+}
+
+func reportProjectBuildBegin(name string, out io.Writer) {
+	fmt.Fprintf(out, "Building project %s...\n", name)
+}
+
+func reportProjectBuildComplete(name string, out io.Writer) {
+	fmt.Fprintf(out, "%s build successful\n", name)
+}
+
+func reportProjectContainerCreateBegin(name string, out io.Writer) {
+	fmt.Fprintf(out, "Perparing %s container...\n", name)
+}
+
+func reportProjectContainerCreateComplete(name string, out io.Writer) {
+	fmt.Fprintf(out, "%s container created\n", name)
+}
+
+func reportProjectStartup(name string, out io.Writer) {
+	fmt.Fprintf(out, "Starting up %s...\n", name)
+}

--- a/daemon/inertiad/containers/containers.go
+++ b/daemon/inertiad/containers/containers.go
@@ -94,10 +94,13 @@ func StopActiveContainers(docker *docker.Client, out io.Writer) error {
 		if container.Names[0] != "/inertia-daemon" {
 			fmt.Fprintln(out, "Stopping "+container.Names[0]+"...")
 			timeout := 10 * time.Second
-			err := docker.ContainerStop(ctx, container.ID, &timeout)
-			if err != nil {
+			if err := docker.ContainerStop(ctx, container.ID, &timeout); err != nil {
 				return err
 			}
+
+			// Archive container
+			docker.ContainerRename(
+				ctx, container.ID, fmt.Sprintf("%s-%d", container.Names[0], time.Now().Unix()))
 		}
 	}
 	return nil

--- a/daemon/inertiad/containers/containers_test.go
+++ b/daemon/inertiad/containers/containers_test.go
@@ -46,8 +46,7 @@ func TestPrune(t *testing.T) {
 	assert.Nil(t, err)
 	defer cli.Close()
 
-	err = Prune(cli)
-	assert.Nil(t, err)
+	Prune(cli)
 }
 
 func TestPruneAll(t *testing.T) {
@@ -55,8 +54,7 @@ func TestPruneAll(t *testing.T) {
 	assert.Nil(t, err)
 	defer cli.Close()
 
-	err = PruneAll(cli, "gliderlabs/herokuish", "docker/compose")
-	assert.Nil(t, err)
+	PruneAll(cli, "gliderlabs/herokuish", "docker/compose")
 
 	// Exceptions should still be present
 	found := false

--- a/daemon/inertiad/log/logger.go
+++ b/daemon/inertiad/log/logger.go
@@ -68,7 +68,7 @@ func (l *DaemonLogger) Println(a interface{}) {
 // WriteErr directs message and status to http.Error when appropriate
 func (l *DaemonLogger) WriteErr(msg string, status int) {
 	fmt.Fprintf(l.Writer, "[ERROR %s] %s\n", strconv.Itoa(status), msg)
-	if l.socket == nil && !l.httpStream {
+	if l.socket == nil {
 		http.Error(l.httpWriter, msg, status)
 	}
 }

--- a/daemon/inertiad/project/deployment.go
+++ b/daemon/inertiad/project/deployment.go
@@ -147,8 +147,7 @@ func (d *Deployment) Deploy(cli *docker.Client, out io.Writer,
 
 	// Update repository
 	if !opts.SkipUpdate {
-		err := git.UpdateRepository(d.directory, d.repo, d.branch, d.auth, out)
-		if err != nil {
+		if err := git.UpdateRepository(d.directory, d.repo, d.branch, d.auth, out); err != nil {
 			return func() error { return nil }, err
 		}
 	}

--- a/daemon/inertiad/prune.go
+++ b/daemon/inertiad/prune.go
@@ -33,5 +33,5 @@ func pruneHandler(w http.ResponseWriter, r *http.Request) {
 		logger.WriteErr(err.Error(), http.StatusInternalServerError)
 		return
 	}
-	logger.WriteSuccess("Project removed from remote.", http.StatusOK)
+	logger.WriteSuccess("Docker assets have been pruned.", http.StatusOK)
 }


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #351

---

## :construction_worker: Changes

See commits - biggest change is that ports exposed in Dockerfile images (via the `EXPOSE` directive) is now automatically mapped to host

## :flashlight: Testing Instructions

build any dockerfile project, check that port is accessible
