### PR TITLE
Exit properly if image build fails

### DIFF
--- a/daemon/inertiad/build/builder.go
+++ b/daemon/inertiad/build/builder.go
@@ -237,18 +237,16 @@ func (b *Builder) dockerBuild(d Config, cli *docker.Client,
 	log.FlushRoutine(out, buildResp.Body, stop)
 	close(stop)
 	buildResp.Body.Close()
-	// todo: detect failures
-	reportProjectBuildComplete(d.Name, out)
-
-	// Get image details
+	// Get image details - this will check if image build was successful
 	image, _, err := cli.ImageInspectWithRaw(ctx, imageName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("image build failed: %s", err.Error())
 	}
 	portMap := nat.PortMap{}
 	for p := range image.Config.ExposedPorts {
 		portMap[p] = []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: p.Port()}}
 	}
+	reportProjectBuildComplete(d.Name, out)
 
 	// Create container from image
 	reportProjectContainerCreateBegin(d.Name, out)

--- a/test/build/dockerfile/fail.Dockerfile
+++ b/test/build/dockerfile/fail.Dockerfile
@@ -1,0 +1,3 @@
+# This dockerfile should fail to build
+FROM alpine
+RUN exit 1


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #349 

---

## :construction_worker: Changes

This was kind of unknowingly fixed by #365, just adjusted the messages a little and added a test to assert the behaviour

## :flashlight: Testing Instructions

Run the updated test