### PR TITLE
Inject version var directly into package cmd

### DIFF
--- a/.scripts/release.sh
+++ b/.scripts/release.sh
@@ -12,5 +12,5 @@ make daemon RELEASE=$RELEASE
 
 # Build Inertia Go binaries for specified platforms
 gox -output="inertia.$(git describe --tags).{{.OS}}.{{.Arch}}" \
-    -ldflags "-w -s -X main.Version=$RELEASE" \
+    -ldflags "-w -s -X github.com/ubclaunchpad/inertia/cmd.Version=$RELEASE" \
     -osarch="$PLATFORMS" \

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
     - &bootstraptest 
       <<: *test
       install: make testenv VPS_OS=debian VPS_VERSION=9.3 SSH_PORT=69
-      script: go test ./... -v -run 'TestBootstrapIntegration' -ldflags "-X main.Version=test"
+      script: go test ./... -v -run 'TestBootstrapIntegration' -ldflags "-X github.com/ubclaunchpad/inertia/cmd.Version=test"
       after_success: true
     - <<: *bootstraptest
       install: make testenv VPS_OS=centos VPS_VERSION=7 SSH_PORT=69

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SSH_PORT = 69
 VPS_VERSION = latest
 VPS_OS = ubuntu
 RELEASE = test
+CLI_VERSION_VAR = github.com/ubclaunchpad/inertia/cmd.Version
 
 all: prod-deps cli
 
@@ -31,12 +32,12 @@ dev-deps:
 # Install Inertia with release version
 .PHONY: cli
 cli:
-	go install -ldflags "-X main.Version=$(RELEASE)"
+	go install -ldflags "-X $(CLI_VERSION_VAR)=$(RELEASE)"
 
 # Install Inertia with git tag as release version
 .PHONY: cli-tagged
 cli-tagged:
-	go install -ldflags "-X main.Version=$(TAG)"
+	go install -ldflags "-X $(CLI_VERSION_VAR)=$(TAG)"
 
 # Remove Inertia binaries
 .PHONY: clean
@@ -54,12 +55,12 @@ lint:
 # Run test suite without Docker ops
 .PHONY: test
 test:
-	go test ./... -short -ldflags "-X main.Version=test" --cover
+	go test ./... -short -ldflags "-X $(CLI_VERSION_VAR)=test" --cover
 
 # Run test suite without Docker ops
 .PHONY: test-v
 test-v:
-	go test ./... -short -ldflags "-X main.Version=test" -v --cover
+	go test ./... -short -ldflags "-X $(CLI_VERSION_VAR)=test" -v --cover
 
 # Run unit and integration tests - creates fresh test VPS and test daemon beforehand
 # Also attempts to run linter
@@ -67,20 +68,20 @@ test-v:
 test-all:
 	make testenv VPS_OS=$(VPS_OS) VPS_VERSION=$(VPS_VERSION)
 	make testdaemon
-	go test ./... -ldflags "-X main.Version=test" --cover
+	go test ./... -ldflags "-X $(CLI_VERSION_VAR)=test" --cover
 
 # Run integration tests verbosely - creates fresh test VPS and test daemon beforehand
 .PHONY: test-integration
 test-integration:
 	make testenv VPS_OS=$(VPS_OS) VPS_VERSION=$(VPS_VERSION)
 	make testdaemon
-	go test ./... -v -run 'Integration' -ldflags "-X main.Version=test" --cover
+	go test ./... -v -run 'Integration' -ldflags "-X $(CLI_VERSION_VAR)=test" --cover
 
 # Run integration tests verbosely without recreating test VPS
 .PHONY: test-integration-fast
 test-integration-fast:
 	make testdaemon
-	go test ./... -v -run 'Integration' -ldflags "-X main.Version=test" --cover
+	go test ./... -v -run 'Integration' -ldflags "-X $(CLI_VERSION_VAR)=test" --cover
 
 # Create test VPS
 .PHONY: testenv

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -40,10 +40,10 @@ func init() {
 		println("[WARNING] Inertia configuration not found in " + configFilePath)
 		return
 	}
-	if config.Version != Root.Version {
+	if config.Version != Version {
 		fmt.Printf(
 			"[WARNING] Configuration version '%s' does not match your Inertia CLI version '%s'\n",
-			config.Version, Root.Version,
+			config.Version, Version,
 		)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,17 @@ import "github.com/spf13/cobra"
 var (
 	// configFilePath is the relative path to Inertia's configuration file
 	configFilePath = "inertia.toml"
+
+	// Version is the current build of Inertia
+	Version string
 )
+
+func getVersion() string {
+	if Version == "" {
+		Version = "latest"
+	}
+	return Version
+}
 
 // Root is the base inertia command
 var Root = &cobra.Command{
@@ -22,5 +32,5 @@ One you have set up a remote with 'inertia remote add [remote]', use
 
 Repository:    https://github.com/ubclaunchpad/inertia/
 Issue tracker: https://github.com/ubclaunchpad/inertia/issues`,
-	Version: "latest",
+	Version: getVersion(),
 }

--- a/inertia.go
+++ b/inertia.go
@@ -4,27 +4,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/ubclaunchpad/inertia/cmd"
 )
 
-var (
-	// Version is the current build of Inertia
-	Version string
-)
-
-func setVersion(c *cobra.Command) {
-	if Version != "" {
-		c.Version = Version
-	} else {
-		c.Version = "latest"
-	}
-}
-
 func main() {
-	root := cmd.Root
-	setVersion(root)
-	if err := root.Execute(); err != nil {
+	if err := cmd.Root.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}

--- a/inertia_test.go
+++ b/inertia_test.go
@@ -2,19 +2,9 @@ package main
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/ubclaunchpad/inertia/cmd"
 )
 
+// This simply tests that everything goes smoothly
 func TestMain(t *testing.T) {
 	main()
-	assert.Equal(t, "latest", cmd.Root.Version)
-}
-
-func TestMainSetVersion(t *testing.T) {
-	Version = "robert"
-	main()
-	assert.Equal(t, Version, cmd.Root.Version)
-	Version = ""
 }


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #367

---

## :construction_worker: Changes

Instead of hacky setting it from `main.Version`... just set `cmd.Version` directly. Oops

## :flashlight: Testing Instructions

```bash
bobbook:inertia robertlin$ make cli RELEASE=chicken
go install -ldflags "-X github.com/ubclaunchpad/inertia/cmd.Version=chicken"
bobbook:inertia robertlin$ inertia --version
[WARNING] Configuration version 'latest' does not match your Inertia CLI version 'chicken'
inertia version chicken
```
