### PR TITLE
Update dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -327,8 +327,8 @@
     "osfs",
     "util"
   ]
-  revision = "027dceab1aa836eb310d92c2eb2266e4dc9f4b81"
-  version = "v4.1.0"
+  revision = "83cf655d40b15b427014d7875d10850f96edba14"
+  version = "v4.2.0"
 
 [[projects]]
   name = "gopkg.in/src-d/go-git.v4"
@@ -386,6 +386,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0103985b533d12aa2263b7c79066df65e25646615e9d0031c237b5b29a673802"
+  inputs-digest = "9a005a1c5b815fbb81a4ea71a970dbcaaaffea924645f76a6bb00fed76058746"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -35,6 +35,7 @@
     "aws/signer/v4",
     "internal/sdkio",
     "internal/sdkrand",
+    "internal/sdkuri",
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/ec2query",
@@ -45,8 +46,8 @@
     "service/ec2",
     "service/sts"
   ]
-  revision = "e4805606f5138247510183050abe642344275ebd"
-  version = "v1.14.10"
+  revision = "859b69a01f8cb52b639bd8c868b116144bddc74a"
+  version = "v1.15.9"
 
 [[projects]]
   name = "github.com/boltdb/bolt"
@@ -218,8 +219,8 @@
 [[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
-  version = "v1.0.5"
+  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
+  version = "v1.0.6"
 
 [[projects]]
   branch = "master"
@@ -362,7 +363,7 @@
     "plumbing/transport/ssh",
     "storage",
     "storage/filesystem",
-    "storage/filesystem/internal/dotgit",
+    "storage/filesystem/dotgit",
     "storage/memory",
     "utils/binary",
     "utils/diff",
@@ -373,8 +374,8 @@
     "utils/merkletrie/internal/frame",
     "utils/merkletrie/noder"
   ]
-  revision = "57570e84f8c5739f0f4a59387493e590e709dde9"
-  version = "v4.4.0"
+  revision = "3bd5e82b2512d85becae9677fa06b5a973fd4cfb"
+  version = "v4.5.0"
 
 [[projects]]
   name = "gopkg.in/warnings.v0"
@@ -385,6 +386,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1503aa8f51f9a57332b3c24cb594808ac39add0fe1ce6222d98b31f14cbbb0e6"
+  inputs-digest = "0103985b533d12aa2263b7c79066df65e25646615e9d0031c237b5b29a673802"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,11 +9,11 @@
 
 [[constraint]]
   name = "gopkg.in/src-d/go-git.v4"
-  version = "4.4.0"
+  version = "4.5.0"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"
-  version = "1.0.5"
+  version = "1.0.6"
 
 [[constraint]]
   name = "github.com/dgrijalva/jwt-go"
@@ -33,16 +33,8 @@
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.14.10"
+  version = "1.15.9"
 
 [[constraint]]
   name = "github.com/docker/docker"
   branch = "master"
-
-[[override]]
-  name = "github.com/docker/distribution"
-  branch = "master"
-
-[[override]]
-  name = "github.com/docker/libnetwork"
-  revision = "19279f0492417475b6bfbd0aa529f73e8f178fb5"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,6 +11,10 @@
   name = "gopkg.in/src-d/go-git.v4"
   version = "4.5.0"
 
+[[override]]
+  name = "gopkg.in/src-d/go-billy.v4"
+  version = "4.2.0"
+
 [[constraint]]
   name = "github.com/sirupsen/logrus"
   version = "1.0.6"


### PR DESCRIPTION
## :construction_worker: Changes

Just some housekeeping.

- `go-git`: v4.4.0 -> v4.5.0
- `logrus`: v1.0.5 -> v1.0.6
- `aws-sdk-go`: v1.14.10 -> 1.15.9
- removed constraints on `docker` dependencies