### PR TITLE
Run all dep ensure commands with -v flag

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ install:
   - go version
   - go env
   - go get -u github.com/golang/dep/cmd/dep
-  - dep ensure
+  - dep ensure -v
 
 deploy: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       script: true
       install:
         - go get github.com/golang/dep/cmd/dep
-        - dep ensure              # cache vendor
+        - dep ensure -v           # cache vendor
         - make testdaemon-image   # cache images
         - make web-deps           # cache node_modules
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR ${BUILD_HOME}
 RUN if [ ! -d "vendor" ]; then \
     apk add --update --no-cache git; \
     go get -u github.com/golang/dep/cmd/dep; \
-    dep ensure; \
+    dep ensure -v; \
     fi
 # Build daemon binary.
 RUN go build -o /bin/inertiad \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ deps: prod-deps dev-deps
 # Sets up production dependencies
 .PHONY: prod-deps
 prod-deps:
-	dep ensure
+	dep ensure -v
 	make web-deps
 
 # Sets up test dependencies


### PR DESCRIPTION
## :construction_worker: Changes

Travis has been pretty consistently failing all the time for no good reason, seemingly on `dep ensure` (though sometimes on loading cache). This changes all `dep ensure` commands to run with the `-v` flag which provides more detailed outputs, for potential debugging purposes.

## :flashlight: Testing Instructions

```
make deps
```