### PR TITLE
Disable git branch test on CI, remove Appveyor workaround

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,10 +30,6 @@ install:
 deploy: false
 
 build_script:
-  - ps: Write-Host "$env:APPVEYOR_REPO_BRANCH"
-  - ps: Write-Host "$env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH"
-  - ps: git checkout -q $env:APPVEYOR_REPO_BRANCH
-  - git branch
   - go build
 
 test_script:

--- a/local/git_test.go
+++ b/local/git_test.go
@@ -17,9 +17,9 @@ func TestGetRepoRemote(t *testing.T) {
 
 func TestGetRepoCurrentBranch(t *testing.T) {
 	// This test does not work on Travis, since Travis cloning doesn't always
-	// set up branches correctly (typically detached)
-	if os.Getenv("TRAVIS") == "true" {
-		t.Skip("skipping test because of Travis")
+	// set up branches correctly (typically detached) - same with Appveyor
+	if os.Getenv("TRAVIS") == "true" || os.Getenv("APPVEYOR") == "True" {
+		t.Skip("skipping test because of CI")
 	}
 	_, err := GetRepoCurrentBranch()
 	if err != nil {


### PR DESCRIPTION
## :construction_worker: Changes

CI typically checkouts exact commits (detached mode), which breaks the `git branch` test. I previously added a workaround for this for Appveyor (#361), which breaks reproducibility of tests. 

However, I just noticed that this was straight up disabled for Travis - which is probably the best approach. This PR removes the workaround and disabled the test on both Travis and Appveyor.