### PR TITLE
Refactor webhook parsing, implement payload verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,11 @@ Inertia is a simple cross-platform command line application that enables quick a
 ----|-----------------
 🚀  | Simple setup from your computer without ever having to manually SSH into your remote
 🍰  | Use any Linux-based remote virtual private server platform you want
-📦  | Easily provision new VPS instances on supported platforms such as Amazon EC2
+📦  | Easily provision VPS instances for your project with supported providers such as Amazon EC2
 ⚒  | Deploy any Dockerfile or docker-compose project
-🚄  | Have your project automatically updated, rebuilt, and deployed as soon as you `git push`
-🛂  | Start up, shut down, and monitor your deployment with ease
-🏷  | Configure deployment to your liking with branch settings and more
-🌐  | Add users and check on your deployment anywhere through Inertia Web
+🚄  | Webhook integration for GitHub, GitLab, and Bitbucket allow your project to be automatically updated, rebuilt, and deployed as soon as you `git push`
+🛂  | Start up, shut down, and monitor your deployment with ease from the command line
+🏷  | Configure deployment to your liking with branch settings, build configuration, and more
 🔑  | Secured with tokens and HTTPS across the board
 
 <br>

--- a/daemon/inertiad/crypto/verify.go
+++ b/daemon/inertiad/crypto/verify.go
@@ -1,0 +1,67 @@
+package crypto
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"strings"
+)
+
+const (
+	// Prefixes used by GitHub before the HMAC hexdigest.
+	sha1Prefix = "sha1"
+)
+
+// ValidateSignature validates the HMAC signature for the given payload.
+// Based off of https://github.com/google/go-github
+func ValidateSignature(signature string, payload, secretKey []byte) error {
+	messageMAC, hashFunc, err := messageMAC(signature)
+	if err != nil {
+		return err
+	}
+	if !checkMAC(payload, messageMAC, secretKey, hashFunc) {
+		return errors.New("payload signature check failed")
+	}
+	return nil
+}
+
+// checkMAC reports whether messageMAC is a valid HMAC tag for message.
+func checkMAC(message, messageMAC, key []byte, hashFunc func() hash.Hash) bool {
+	mac := hmac.New(hashFunc, key)
+	mac.Write(message)
+	return hmac.Equal(messageMAC, mac.Sum(nil))
+}
+
+// messageMAC returns the hex-decoded HMAC tag from the signature and its
+// corresponding hash function.
+func messageMAC(signature string) ([]byte, func() hash.Hash, error) {
+	if signature == "" {
+		return nil, nil, errors.New("missing signature")
+	}
+	sigParts := strings.SplitN(signature, "=", 2)
+	if len(sigParts) != 2 {
+		return nil, nil, fmt.Errorf("error parsing signature %q", signature)
+	}
+
+	var (
+		signaturePrefix  = sigParts[0]
+		payloadSignature = sigParts[1]
+		hashFunc         func() hash.Hash
+	)
+
+	switch signaturePrefix {
+	case sha1Prefix:
+		hashFunc = sha1.New
+	default:
+		return nil, nil, fmt.Errorf("unknown hash type prefix: %q", signaturePrefix)
+	}
+
+	buf, err := hex.DecodeString(payloadSignature)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error decoding signature %q: %v", signature, err)
+	}
+	return buf, hashFunc, nil
+}

--- a/daemon/inertiad/crypto/verify_test.go
+++ b/daemon/inertiad/crypto/verify_test.go
@@ -1,0 +1,33 @@
+package crypto
+
+import "testing"
+
+var (
+	testSignature = "sha1=126f2c800419c60137ce748d7672e77b65cf16d6"
+	testPayload   = []byte(`{"yo":true}`)
+	testKey       = []byte("0123456789abcdef")
+)
+
+func TestValidateSignature(t *testing.T) {
+	type args struct {
+		signature string
+		payload   []byte
+		secretKey []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"ok", args{testSignature, testPayload, testKey}, false},
+		{"missing sig", args{"", testPayload, testKey}, true},
+		{"incorrect sig", args{testSignature, testPayload, []byte("ohno")}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateSignature(tt.args.signature, tt.args.payload, tt.args.secretKey); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateSignature() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/daemon/inertiad/webhook.go
+++ b/daemon/inertiad/webhook.go
@@ -18,9 +18,20 @@ var webhookSecret = "inertia"
 // Supported vendors: Github, Gitlab, Bitbucket
 // Supported events: push
 func webhookHandler(w http.ResponseWriter, r *http.Request) {
-	payload, err := webhook.Parse(r)
+	// check type
+	host, event := webhook.Type(r)
+
+	// ensure validity
+	if err := webhook.Verify(host, webhookSecret, r); err != nil {
+		http.Error(w, "unable to verify payload: "+err.Error(), http.StatusBadRequest)
+		fmt.Fprintln(os.Stdout, err.Error())
+		return
+	}
+
+	// retrieve payload
+	payload, err := webhook.Parse(host, event, r)
 	if err != nil {
-		http.Error(w, "unable to parse payload", http.StatusBadRequest)
+		http.Error(w, "unable to parse payload: "+err.Error(), http.StatusBadRequest)
 		fmt.Fprintln(os.Stdout, err.Error())
 		return
 	}

--- a/daemon/inertiad/webhook.go
+++ b/daemon/inertiad/webhook.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/webhook"
 )
 
-var webhookSecret = "inertia"
+var webhookSecret = ""
 
 // webhookHandler receives and parses Git-based webhooks
 // Supported vendors: Github, Gitlab, Bitbucket
@@ -24,7 +24,7 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		msg := "unable to read payload: " + err.Error()
 		http.Error(w, msg, http.StatusBadRequest)
-		fmt.Fprintln(os.Stdout, msg)
+		println(msg)
 		return
 	}
 
@@ -32,10 +32,13 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
 	host, event := webhook.Type(r.Header)
 
 	// ensure validity
+	if webhookSecret == "" {
+		println("warning: no webhook secret is set up yet! set one in inertia.toml and run inertia [remote] up")
+	}
 	if err := webhook.Verify(host, webhookSecret, r.Header, body); err != nil {
 		msg := "unable to verify payload: " + err.Error()
 		http.Error(w, msg, http.StatusBadRequest)
-		fmt.Fprintln(os.Stdout, msg)
+		println(msg)
 		return
 	}
 
@@ -44,7 +47,7 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		msg := "unable to parse payload: " + err.Error()
 		http.Error(w, msg, http.StatusBadRequest)
-		fmt.Fprintln(os.Stdout, msg)
+		println(msg)
 		return
 	}
 
@@ -58,7 +61,7 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
 	// 	processPullRequestEvent(payload)
 	default:
 		http.Error(w, "unrecognized event type", http.StatusBadRequest)
-		fmt.Fprintln(os.Stdout, "Unrecognized event type")
+		println("unrecognized event type")
 	}
 }
 
@@ -70,7 +73,7 @@ func dockerWebhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Fprintf(os.Stdout, "Received dockerhub webhook event: %s:%s\n", p.GetRepoName(), p.GetTag())
+	fmt.Printf("Received dockerhub webhook event: %s:%s\n", p.GetRepoName(), p.GetTag())
 }
 
 // processPushEvent prints information about the given PushEvent.

--- a/daemon/inertiad/webhook/bitbucket.go
+++ b/daemon/inertiad/webhook/bitbucket.go
@@ -14,6 +14,6 @@ func parseBitbucketEvent(rawJSON map[string]interface{}, event string) (Payload,
 	case BitbucketPushHeader:
 		return parseBitbucketPushEvent(rawJSON), nil
 	default:
-		return nil, errors.New("Unsupported Bitbucket event")
+		return nil, errors.New("unsupported Bitbucket event")
 	}
 }

--- a/daemon/inertiad/webhook/github.go
+++ b/daemon/inertiad/webhook/github.go
@@ -15,6 +15,6 @@ func parseGithubEvent(rawJSON map[string]interface{}, event string) (Payload, er
 	case GithubPushHeader:
 		return parseGithubPushEvent(rawJSON), nil
 	default:
-		return nil, errors.New("Unsupported Github event")
+		return nil, errors.New("unsupported Github event")
 	}
 }

--- a/daemon/inertiad/webhook/gitlab.go
+++ b/daemon/inertiad/webhook/gitlab.go
@@ -14,6 +14,6 @@ func parseGitlabEvent(rawJSON map[string]interface{}, event string) (Payload, er
 	case GitlabPushHeader:
 		return parseGitlabPushEvent(rawJSON), nil
 	default:
-		return nil, errors.New("Unsupported Gitlab event")
+		return nil, errors.New("unsupported Gitlab event")
 	}
 }

--- a/daemon/inertiad/webhook/parse_test.go
+++ b/daemon/inertiad/webhook/parse_test.go
@@ -15,7 +15,8 @@ func getMockRequest(endpoint string, rawBody []byte) *http.Request {
 	req.Header.Add("Content-Type", "application/json")
 	return req
 }
-func TestParse(t *testing.T) {
+
+func TestTypeAndParse(t *testing.T) {
 	testCases := []struct {
 		source      string
 		reqBody     []byte
@@ -26,7 +27,6 @@ func TestParse(t *testing.T) {
 		{GitLab, gitlabPushRawJSON, "x-gitlab-event", GitlabPushHeader},
 		{BitBucket, bitbucketPushRawJSON, "x-event-key", BitbucketPushHeader},
 	}
-
 	for _, tc := range testCases {
 		req := getMockRequest("/webhook", tc.reqBody)
 		req.Header.Add(tc.eventHeader, tc.eventValue)
@@ -36,7 +36,11 @@ func TestParse(t *testing.T) {
 			req.Header.Add("User-Agent", "Bitbucket")
 		}
 
-		payload, err := Parse(req)
+		// Parse type
+		host, event := Type(req)
+
+		// Parse payload
+		payload, err := Parse(host, event, req)
 		assert.Nil(t, err)
 
 		assert.Equal(t, tc.source, payload.GetSource())

--- a/daemon/inertiad/webhook/parse_test.go
+++ b/daemon/inertiad/webhook/parse_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -37,10 +38,14 @@ func TestTypeAndParse(t *testing.T) {
 		}
 
 		// Parse type
-		host, event := Type(req)
+		host, event := Type(req.Header)
+
+		// Read
+		body, err := ioutil.ReadAll(req.Body)
+		assert.Nil(t, err)
 
 		// Parse payload
-		payload, err := Parse(host, event, req)
+		payload, err := Parse(host, event, req.Header, body)
 		assert.Nil(t, err)
 
 		assert.Equal(t, tc.source, payload.GetSource())

--- a/daemon/inertiad/webhook/verify.go
+++ b/daemon/inertiad/webhook/verify.go
@@ -2,7 +2,6 @@ package webhook
 
 import (
 	"errors"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/crypto"
@@ -16,28 +15,24 @@ const (
 
 // Verify ensures the payload's integrity and returns and error if anything
 // doesn't match up
-func Verify(host, key string, r *http.Request) (err error) {
+func Verify(host, key string, h http.Header, body []byte) (err error) {
 	switch host {
 	case BitBucket:
 		// Bitbucket server has HMAC verification (same as GitHub), but not
 		// the standard Bitbucket, it seems.
-		if r.Header.Get(xHubSignatureHeader) == "" {
+		if h.Get(xHubSignatureHeader) == "" {
 			return nil // assume the event is valid
 		}
 		fallthrough // use same validation as GitHub
 	case GitHub:
 		// https://developer.github.com/webhooks/securing/
-		var payloadBytes []byte
-		if payloadBytes, err = ioutil.ReadAll(r.Body); err != nil {
-			return nil
-		}
 		return crypto.ValidateSignature(
-			r.Header.Get(xHubSignatureHeader),
-			payloadBytes,
+			h.Get(xHubSignatureHeader),
+			body,
 			[]byte(key))
 	case GitLab:
 		// https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#secret-token
-		token := r.Header.Get(gitlabTokenHeader)
+		token := h.Get(gitlabTokenHeader)
 		if token != key {
 			return errors.New("invalid webhook token")
 		}

--- a/daemon/inertiad/webhook/verify.go
+++ b/daemon/inertiad/webhook/verify.go
@@ -1,0 +1,48 @@
+package webhook
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/ubclaunchpad/inertia/daemon/inertiad/crypto"
+)
+
+const (
+	// Signatures
+	xHubSignatureHeader = "X-Hub-Signature"
+	gitlabTokenHeader   = "X-Gitlab-Token"
+)
+
+// Verify ensures the payload's integrity and returns and error if anything
+// doesn't match up
+func Verify(host, key string, r *http.Request) (err error) {
+	switch host {
+	case BitBucket:
+		// Bitbucket server has HMAC verification (same as GitHub), but not
+		// the standard Bitbucket, it seems.
+		if r.Header.Get(xHubSignatureHeader) == "" {
+			return nil // assume the event is valid
+		}
+		fallthrough // use same validation as GitHub
+	case GitHub:
+		// https://developer.github.com/webhooks/securing/
+		var payloadBytes []byte
+		if payloadBytes, err = ioutil.ReadAll(r.Body); err != nil {
+			return nil
+		}
+		return crypto.ValidateSignature(
+			r.Header.Get(xHubSignatureHeader),
+			payloadBytes,
+			[]byte(key))
+	case GitLab:
+		// https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#secret-token
+		token := r.Header.Get(gitlabTokenHeader)
+		if token != key {
+			return errors.New("invalid webhook token")
+		}
+		return nil
+	default:
+		return errors.New("unsupported type")
+	}
+}

--- a/daemon/inertiad/webhook/verify_test.go
+++ b/daemon/inertiad/webhook/verify_test.go
@@ -1,0 +1,78 @@
+package webhook
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testBody      = `{"yo":true}`
+	testSignature = "sha1=126f2c800419c60137ce748d7672e77b65cf16d6"
+	testKey       = "0123456789abcdef"
+)
+
+func TestVerify(t *testing.T) {
+	type args struct {
+		host      string
+		body      string
+		header    string
+		signature string
+		key       string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		// ok cases
+		{
+			"bitbucket",
+			args{BitBucket, testBody, xHubSignatureHeader, testSignature, testKey},
+			false,
+		},
+		{
+			"github",
+			args{GitHub, testBody, xHubSignatureHeader, testSignature, testKey},
+			false,
+		},
+		{
+			"gitlab",
+			args{GitLab, testBody, gitlabTokenHeader, testKey, testKey},
+			false,
+		},
+
+		// not ok cases
+		{
+			"no signature",
+			args{BitBucket, testBody, xHubSignatureHeader, "", testKey},
+			true,
+		},
+		{
+			"signature mismatch",
+			args{BitBucket, testBody, xHubSignatureHeader, testSignature, "ohno"},
+			true,
+		},
+		{
+			"token mismatch",
+			args{GitLab, testBody, gitlabTokenHeader, "", testKey},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := bytes.NewBufferString(tt.args.body)
+			req, err := http.NewRequest("GET", "http://127.0.0.1/webhook", buf)
+			assert.Nil(t, err)
+
+			req.Header.Set(tt.args.header, tt.args.signature)
+			req.Header.Set("Content-Type", "application/json")
+
+			if err := Verify(tt.args.host, tt.args.key, req); (err != nil) != tt.wantErr {
+				t.Errorf("Verify() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/daemon/inertiad/webhook_test.go
+++ b/daemon/inertiad/webhook_test.go
@@ -36,7 +36,7 @@ func Test_webhookHandler(t *testing.T) {
 				"X-GitHub-Event":  "watch",
 				"X-Hub-Signature": testSignature,
 			},
-		}, http.StatusBadRequest, "Unsupported Github event"},
+		}, http.StatusBadRequest, "unsupported Github event"},
 		{"no signature", args{
 			testKey,
 			map[string]string{

--- a/daemon/inertiad/webhook_test.go
+++ b/daemon/inertiad/webhook_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testBody      = `{"yo":true}`
+	testSignature = "sha1=126f2c800419c60137ce748d7672e77b65cf16d6"
+	testKey       = "0123456789abcdef"
+)
+
+func TestWebhookHandler_notPush(t *testing.T) {
+	webhookSecret = testKey
+	recorder := httptest.NewRecorder()
+	handler := http.HandlerFunc(webhookHandler)
+
+	handler.ServeHTTP(recorder, getTestWebhookEvent())
+	assert.Equal(t, recorder.Code, http.StatusBadRequest)
+
+	b, err := ioutil.ReadAll(recorder.Body)
+	assert.Nil(t, err)
+	assert.Contains(t, string(b), "Unsupported Github event")
+}
+
+func getTestWebhookEvent() *http.Request {
+	buf := bytes.NewBufferString(testBody)
+	req, err := http.NewRequest("POST", "http://127.0.0.1/webhook", buf)
+	if err != nil {
+		os.Exit(1)
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("User-Agent", "GitHub-Hookshot/539d755")
+	req.Header.Set("X-GitHub-Event", "watch")
+	req.Header.Set("X-Hub-Signature", testSignature)
+	return req
+}


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #390

---

## :construction_worker: Changes

- Refactor webhook parsing to accomodate new `webhook.Verify()` step
- New package `crypto` function for HMAC signature validation
- Use HMAC verification where appropriate (GitHub, some BitBucket)
    - based off of go-github's implementation - similar tests pass, so hopefully it is correct
- Use simple token verification for GitLab as per documentation

## :flashlight: Testing Instructions

```
make test
```
