### PR TITLE
Remove go-metalinter, use go vet, golint, etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
     #   install: make testenv VPS_OS=amazon VPS_VERSION=2 SSH_PORT=69
 
     # Run linter and static analysis
-    - install: bash test/lint_deps.sh
+    - install: go get -u golang.org/x/lint/golint
       script: make lint
 
     ############################

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ prod-deps:
 .PHONY: dev-deps
 dev-deps:
 	go get -u github.com/UnnoTed/fileb0x
+	go get -u golang.org/x/lint/golint
 	bash test/docker_deps.sh
-	bash test/lint_deps.sh
 
 # Install Inertia with release version
 .PHONY: cli
@@ -49,7 +49,10 @@ clean:
 # Run static analysis
 .PHONY: lint
 lint:
-	PATH=$(PATH):./bin bash -c './bin/gometalinter --vendor --deadline=120s ./...'
+	go vet ./...
+	go test -run xxxx ./...
+	go fmt ./...
+	golint `go list ./... | grep -v /vendor/`
 	(cd ./daemon/web; npm run lint)
 	(cd ./daemon/web; npm run sass-lint)
 

--- a/daemon/inertiad/auth/users.go
+++ b/daemon/inertiad/auth/users.go
@@ -152,7 +152,7 @@ func (m *userManager) IsCorrectCredentials(username, password string) (*userProp
 		userErr   error
 		correct   bool
 	)
-	
+
 	if username == "" || password == "" {
 		return nil, false, errors.New("Invalid credentials provided")
 	}


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #411

---

## :construction_worker: Changes

Removed go-metalinter which sucked
Added go vet, golint, etc. We lose on some of the fancier static analysis stuff (no-ineff-assign, useless return checks, etc) but oh well.

## :flashlight: Testing Instructions

```
make deps
make lint
```