### PR TITLE
[WIP] Allow clients to authenticate via the CLI

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -245,6 +245,14 @@ func (c *Client) Up(gitRemoteURL, buildType string, stream bool) (*http.Response
 	})
 }
 
+// LogIn gets an access token for the user with the given credentials
+func (c *Client) LogIn(user string, password string) (*http.Response, error) {
+	return c.post("/user/login", &common.UserRequest{
+		Username: user,
+		Password: password,
+	})
+}
+
 // Token generates token on this remote.
 func (c *Client) Token() (*http.Response, error) {
 	return c.get("/token", nil)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -552,3 +552,33 @@ func TestToken(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
+
+func TestLogIn(t *testing.T) {
+	username := "testguy"
+	password := "SomeKindo23asdfpassword"
+	testServer := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+
+		// Check request method
+		assert.Equal(t, http.MethodPost, req.Method)
+
+		// Check correct endpoint called
+		endpoint := req.URL.Path
+		assert.Equal(t, "/user/login", endpoint)
+
+		// Check auth
+		defer req.Body.Close()
+		body, err := ioutil.ReadAll(req.Body)
+		assert.Equal(t, nil, err)
+		var userReq common.UserRequest
+		assert.Equal(t, nil, json.Unmarshal(body, &userReq))
+		assert.Equal(t, userReq.Username, username)
+		assert.Equal(t, userReq.Password, password)
+	}))
+	defer testServer.Close()
+
+	d := getMockClient(testServer)
+	resp, err := d.LogIn(username, password)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -82,6 +82,7 @@ Run 'inertia [remote] init' to gather this information.`,
 		adduser := deepCopy(cmdDeploymentAddUser)
 		adduser.Flags().Bool("admin", false, "create a user with administrator permissions")
 		user.AddCommand(adduser)
+		user.AddCommand(deepCopy(cmdDeploymentLogin))
 		user.AddCommand(deepCopy(cmdDeploymentRemoveUser))
 		user.AddCommand(deepCopy(cmdDeploymentResetUsers))
 		user.AddCommand(deepCopy(cmdDeploymentListUsers))

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -108,6 +108,58 @@ from the web app.`,
 	},
 }
 
+var cmdDeploymentLogin = &cobra.Command{
+	Use:   "login",
+	Short: "Authenticate with the remote",
+	Long:  "Retreives an access token from the remote using your credentials.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		remoteName := strings.Split(cmd.Parent().Parent().Use, " ")[0]
+		deployment, _, err := local.GetClient(remoteName, configFilePath, cmd)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		username := args[0]
+		fmt.Print("Password: ")
+		pwBytes, err := terminal.ReadPassword(int(syscall.Stdin))
+		fmt.Println()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		resp, err := deployment.LogIn(username, string(pwBytes))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if resp.StatusCode != http.StatusAccepted {
+			fmt.Println("Invalid username or password")
+			return
+		}
+
+		config, path, err := local.GetProjectConfigFromDisk(configFilePath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		defer resp.Body.Close()
+		token, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		config.Remotes[remoteName].Daemon.Token = string(token)
+		config.Remotes[remoteName].User = username
+		err = config.Write(path)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Println("You have been logged in successfully.")
+	},
+}
+
 var cmdDeploymentResetUsers = &cobra.Command{
 	Use:   "reset",
 	Short: "Reset user database on your remote",

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -109,7 +109,7 @@ from the web app.`,
 }
 
 var cmdDeploymentLogin = &cobra.Command{
-	Use:   "login",
+	Use:   "login [user]",
 	Short: "Authenticate with the remote",
 	Long:  "Retreives an access token from the remote using your credentials.",
 	Args:  cobra.ExactArgs(1),


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #421 

---

@bobheadxi I marked this as WIP because I'm not sure we can actually merge this yet. With the functionality I've added, if you log in as a regular user while you hold the master token, that master token will be overwritten with the auth token for the user you logged in as. Is there a way to add regular credentials to the master account as-is, or will we need to implement that? 

## :construction_worker: Changes

- Added `LogIn` method to `users.go` that hits the `/user/auth` endpoint with the user's credentials and returns the response.
- Added tests for `LogIn()`.
- Added a `login` command that accepts the user's credentials (password is hidden and can't be specified as an argument) and uses them to retrieve an auth token. The `inertia.toml` config file is then updated with the username and token if the authentication succeeds.

## :flashlight: Testing Instructions

Just run the tests, or use the login command as a regular, non-master user.
