### PR TITLE
Totp/#417 crypto

### DIFF
--- a/daemon/inertiad/crypto/totp.go
+++ b/daemon/inertiad/crypto/totp.go
@@ -14,12 +14,13 @@ const (
 	totpSecretSize       = 10
 	totpDigits           = 6
 	totpAlgorithm        = otp.AlgorithmSHA1
-	totpNoBackupCodes    = 10
+	// TotpNoBackupCodes is the number of backup codes per user
+	TotpNoBackupCodes    = 10
 	totpBackupCodeLength = 5
 )
 
-// Generates secret key object which can be turned into string or image
-func generateSecretKey(accountName string) (*otp.Key, error) {
+// GenerateSecretKey creates a new key which can be turned into string or image
+func GenerateSecretKey(accountName string) (*otp.Key, error) {
 	return totp.Generate(totp.GenerateOpts{
 		Issuer:      totpIssuerName,
 		AccountName: accountName,
@@ -30,18 +31,20 @@ func generateSecretKey(accountName string) (*otp.Key, error) {
 	})
 }
 
-// Validate one-time passcode against original secret key
-func validatePasscode(passcode string, secret string) bool {
+// ValidatePasscode validates a one-time passcode against a secret key
+func ValidatePasscode(passcode string, secret string) bool {
 	return totp.Validate(passcode, secret)
 }
 
-// Generates backup code strings in Github format
+// GenerateBackupCodes generates an array of backup code strings in
+// Github format.
 //
+// Example:
 // b2e03-ffbcf
 // cebe6-b1bdd
 // ...
-func generateBackupCodes() (backupCodes [totpNoBackupCodes]string) {
-	for i := 0; i < totpNoBackupCodes; i++ {
+func GenerateBackupCodes() (backupCodes [TotpNoBackupCodes]string) {
+	for i := 0; i < TotpNoBackupCodes; i++ {
 		// get random bytes
 		randomBytes := make([]byte, totpBackupCodeLength)
 		rand.Read(randomBytes)

--- a/daemon/inertiad/crypto/totp.go
+++ b/daemon/inertiad/crypto/totp.go
@@ -9,11 +9,11 @@ import (
 )
 
 const (
-	totpIssuerName       = "Inertia"
-	totpPeriod           = 30
-	totpSecretSize       = 10
-	totpDigits           = 6
-	totpAlgorithm        = otp.AlgorithmSHA1
+	totpIssuerName = "Inertia"
+	totpPeriod     = 30
+	totpSecretSize = 10
+	totpDigits     = 6
+	totpAlgorithm  = otp.AlgorithmSHA1
 	// TotpNoBackupCodes is the number of backup codes per user
 	TotpNoBackupCodes    = 10
 	totpBackupCodeLength = 5

--- a/daemon/inertiad/crypto/totp_test.go
+++ b/daemon/inertiad/crypto/totp_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGeneration(t *testing.T) {
-	key, err := generateSecretKey("TestAccountName")
+	key, err := GenerateSecretKey("TestAccountName")
 	assert.Nil(t, err)
 
 	// string form of secret
@@ -23,7 +23,7 @@ func TestGeneration(t *testing.T) {
 
 func TestVerification(t *testing.T) {
 
-	key, err := generateSecretKey("TestAccountName")
+	key, err := GenerateSecretKey("TestAccountName")
 	assert.Nil(t, err)
 	currentTime := time.Now()
 
@@ -53,15 +53,15 @@ func TestVerification(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			code, err := totp.GenerateCode(key.Secret(), test.in)
 			assert.Nil(t, err)
-			assert.Equal(t, validatePasscode(code, key.Secret()), test.out)
+			assert.Equal(t, ValidatePasscode(code, key.Secret()), test.out)
 		})
 
 	}
 }
 
 func TestBackupCodes(t *testing.T) {
-	codes := generateBackupCodes()
-	assert.Equal(t, len(codes), totpNoBackupCodes)
+	codes := GenerateBackupCodes()
+	assert.Equal(t, len(codes), TotpNoBackupCodes)
 	for _, code := range codes {
 		assert.Equal(t, len(code), 11)
 	}


### PR DESCRIPTION
:tickets: **Ticket(s)**: #417

---

## :construction_worker: Changes

Makes TOTP methods public as well as hash codes constant.

This is needed for #418

## :flashlight: Testing Instructions

totp_test.go
