### PR TITLE
Add warning that GitHub webhook Content-Type must be JSON

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -122,6 +122,9 @@ func (c *Client) BootstrapRemote(repoName string) error {
 	fmt.Fprint(c.out, "\n"+`Note that you will have to disable SSH verification in your webhook
 settings - Inertia uses self-signed certificates that GitHub won't
 be able to verify.`+"\n")
+	fmt.Fprint(c.out, "\n"+`Note that you will also have to set the Content-Type for your webhook
+to application/json - GitHub defaults to application/x-www-form-urlencoded, which is not yet
+supported.`+"\n")
 
 	fmt.Fprint(c.out, "\n"+`Inertia daemon successfully deployed! Add your webhook url and deploy
 key to your repository to enable continuous deployment.`+"\n")


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #444

---

## :construction_worker: Changes
Adds a brief warning that Content-Type for GitHub webhook must be JSON after providing it.