### PR TITLE
Add note about default testenv SSH port

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,7 @@ $> inertia remote add local
 # - PEM file: $INERTIA_PATH/test/keys/id_rsa
 # - Address:  127.0.0.1 
 # - User:     root
+$> inertia remote set local ssh-port 69 # defaults to 69
 $> inertia local init
 $> inertia local status
 ```


### PR DESCRIPTION
:tickets: **Ticket(s)**: n/a

---

## :construction_worker: Changes

SSH port [defaults to 69](https://github.com/ubclaunchpad/inertia/blob/master/Makefile#L2), this change updates instructions to reflect that

## :flashlight: Testing Instructions

See docs
