### PR TITLE
Warn if no project ports are provided

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -74,6 +74,12 @@ This ensures that your project ports are properly exposed and externally accessi
 		var instanceType, _ = cmd.Flags().GetString("type")
 		var stringProjectPorts, _ = cmd.Flags().GetStringArray("ports")
 
+		if stringProjectPorts == nil || len(stringProjectPorts) == 0 {
+			fmt.Print("[WARNING] no project ports provided - this means that no ports" +
+				"will be exposed on your ec2 host. Use the '--ports' flag to set" +
+				"ports that you want to be accessible.")
+		}
+
 		// Create VPS instance
 		var prov *provision.EC2Provisioner
 		if fromEnv {


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #442 

---

## :construction_worker: Changes

It's super easy to forget to provide project ports, which means you'll get provisioned an EC2 host with no ports exposed - this change adds a warning to make sure a lack of ports intentional

## :flashlight: Testing Instructions

n/a