### PR TITLE
dist: build darwin/amd64 instead of darwin/386

### DIFF
--- a/.scripts/release.sh
+++ b/.scripts/release.sh
@@ -1,14 +1,15 @@
+#! /bin/bash
 
 # Download our release binary builder
 go get -u github.com/mitchellh/gox
 
 # Specify platforms and release version
-PLATFORMS="linux/amd64 linux/386 darwin/386 windows/amd64 windows/386"
+PLATFORMS="linux/amd64 linux/386 darwin/amd64 windows/amd64 windows/386"
 RELEASE=$(git describe --tags)
 echo "Building release $RELEASE"
 
 # Build, tag and push Inertia Docker image
-make daemon RELEASE=$RELEASE
+make daemon RELEASE="$RELEASE"
 
 # Build Inertia Go binaries for specified platforms
 gox -output="inertia.$(git describe --tags).{{.OS}}.{{.Arch}}" \


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #379 

---

## :construction_worker: Changes

Remove darwin/386, add darwin/amd64
Minor lint improvements of the release script

## :flashlight: Testing Instructions

```
bash .scripts/release.sh
```
