### PR TITLE
cmd: fix minor spacing inconsistencies

### DIFF
--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -33,10 +33,10 @@ Inertia remotes.
 Requires Inertia to be set up via 'inertia init'.
 
 For example:
-    inertia init
-    inertia remote add gcloud
-    inertia gcloud init        # set up Inertia
-	inertia gcloud status      # check on status of Inertia daemon
+  inertia init
+  inertia remote add gcloud
+  inertia gcloud init        # set up Inertia
+  inertia gcloud status      # check on status of Inertia daemon
 `,
 }
 


### PR DESCRIPTION
:tickets: **Ticket(s)**: n/a

---

## :construction_worker: Changes

Noticed some minor inconsistencies in the spacing on this particular docstring

## :flashlight: Testing Instructions

```
inertia remote
```
