### PR TITLE
deploy: persist sent files

### DIFF
--- a/daemon/inertiad/git/git.go
+++ b/daemon/inertiad/git/git.go
@@ -63,8 +63,8 @@ func clone(remoteURL string, opts RepoOptions, out io.Writer) (*gogit.Repository
 	if err = SimplifyGitErr(err); err != nil {
 		return nil, err
 	}
-	// Use this to confirm if pull has completed.
 
+	// Use this to confirm if pull has completed.
 	if _, err = repo.Head(); err != nil {
 		return nil, err
 	}
@@ -81,10 +81,12 @@ func UpdateRepository(repo *gogit.Repository, opts RepoOptions, out io.Writer) e
 
 	fmt.Fprintln(out, "Fetching repository...")
 	err = repo.Fetch(&gogit.FetchOptions{
-		Auth:     opts.Auth,
-		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
-		Progress: out,
-		Force:    true,
+		RemoteName: "origin",
+		Auth:       opts.Auth,
+		RefSpecs:   []config.RefSpec{"refs/*:refs/*"},
+		Tags:       gogit.AllTags,
+		Progress:   out,
+		Force:      true,
 	})
 	if err = SimplifyGitErr(err); err != nil {
 		return err
@@ -94,6 +96,7 @@ func UpdateRepository(repo *gogit.Repository, opts RepoOptions, out io.Writer) e
 	fmt.Fprintf(out, "Checking out %s...\n", ref)
 	err = tree.Checkout(&gogit.CheckoutOptions{
 		Branch: ref,
+		Force:  true,
 	})
 	if err = SimplifyGitErr(err); err != nil {
 		return err
@@ -106,6 +109,8 @@ func UpdateRepository(repo *gogit.Repository, opts RepoOptions, out io.Writer) e
 		Auth:          opts.Auth,
 		Progress:      out,
 		Force:         true,
+
+		RecurseSubmodules: gogit.DefaultSubmoduleRecursionDepth,
 	})
 	return SimplifyGitErr(err)
 }

--- a/daemon/inertiad/git/git.go
+++ b/daemon/inertiad/git/git.go
@@ -29,11 +29,17 @@ func SimplifyGitErr(err error) error {
 	return nil
 }
 
+// RepoOptions declares options for a project repository
+type RepoOptions struct {
+	Directory string
+	Branch    string
+	Auth      transport.AuthMethod
+}
+
 // InitializeRepository sets up a project repository for the first time
-func InitializeRepository(directory, remoteURL, branch string, authMethod transport.AuthMethod, w io.Writer) (*gogit.Repository, error) {
+func InitializeRepository(remoteURL string, opts RepoOptions, w io.Writer) (*gogit.Repository, error) {
 	fmt.Fprintln(w, "Setting up project...")
-	// Clone project
-	repo, err := clone(directory, remoteURL, branch, authMethod, w)
+	repo, err := clone(remoteURL, opts, w)
 	if err != nil {
 		if err == ErrInvalidGitAuthentication {
 			return nil, AuthFailedErr()
@@ -45,30 +51,29 @@ func InitializeRepository(directory, remoteURL, branch string, authMethod transp
 
 // clone wraps gogit.PlainClone() and returns a more helpful error message
 // if the given error is an authentication-related error.
-func clone(directory, remoteURL, branch string, auth transport.AuthMethod, out io.Writer) (*gogit.Repository, error) {
-	fmt.Fprintf(out, "Cloning branch %s from %s...\n", branch, remoteURL)
-	ref := plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", branch))
-	repo, err := gogit.PlainClone(directory, false, &gogit.CloneOptions{
+func clone(remoteURL string, opts RepoOptions, out io.Writer) (*gogit.Repository, error) {
+	fmt.Fprintf(out, "Cloning branch %s from %s...\n", opts.Branch, remoteURL)
+	ref := plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", opts.Branch))
+	repo, err := gogit.PlainClone(opts.Directory, false, &gogit.CloneOptions{
 		URL:           remoteURL,
-		Auth:          auth,
+		Auth:          opts.Auth,
 		Progress:      out,
 		ReferenceName: ref,
 	})
-	err = SimplifyGitErr(err)
-	if err != nil {
+	if err = SimplifyGitErr(err); err != nil {
+		return nil, err
+	}
+	// Use this to confirm if pull has completed.
+
+	if _, err = repo.Head(); err != nil {
 		return nil, err
 	}
 
-	// Use this to confirm if pull has completed.
-	_, err = repo.Head()
-	if err != nil {
-		return nil, err
-	}
 	return repo, nil
 }
 
 // UpdateRepository pulls and checkouts given branch from repository
-func UpdateRepository(directory string, repo *gogit.Repository, branch string, auth transport.AuthMethod, out io.Writer) error {
+func UpdateRepository(repo *gogit.Repository, opts RepoOptions, out io.Writer) error {
 	tree, err := repo.Worktree()
 	if err != nil {
 		return err
@@ -76,23 +81,21 @@ func UpdateRepository(directory string, repo *gogit.Repository, branch string, a
 
 	fmt.Fprintln(out, "Fetching repository...")
 	err = repo.Fetch(&gogit.FetchOptions{
-		Auth:     auth,
+		Auth:     opts.Auth,
 		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
 		Progress: out,
 		Force:    true,
 	})
-	err = SimplifyGitErr(err)
-	if err != nil {
+	if err = SimplifyGitErr(err); err != nil {
 		return err
 	}
 
-	ref := plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", branch))
+	var ref = plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", opts.Branch))
 	fmt.Fprintf(out, "Checking out %s...\n", ref)
 	err = tree.Checkout(&gogit.CheckoutOptions{
 		Branch: ref,
 	})
-	err = SimplifyGitErr(err)
-	if err != nil {
+	if err = SimplifyGitErr(err); err != nil {
 		return err
 	}
 
@@ -100,7 +103,7 @@ func UpdateRepository(directory string, repo *gogit.Repository, branch string, a
 	err = tree.Pull(&gogit.PullOptions{
 		RemoteName:    "origin",
 		ReferenceName: ref,
-		Auth:          auth,
+		Auth:          opts.Auth,
 		Progress:      out,
 		Force:         true,
 	})

--- a/daemon/inertiad/git/git_test.go
+++ b/daemon/inertiad/git/git_test.go
@@ -17,8 +17,11 @@ func TestCloneIntegration(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	dir := "./test_clone/"
-	repo, err := clone(dir, inertiaDeployTest, "dev", nil, os.Stdout)
+	var dir = "./test_clone/"
+	repo, err := clone(inertiaDeployTest, RepoOptions{
+		Directory: dir,
+		Branch:    "dev",
+	}, os.Stdout)
 	defer os.RemoveAll(dir)
 	assert.Nil(t, err)
 
@@ -40,8 +43,8 @@ func TestUpdateRepositoryIntegration(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Try switching branches
-	err = UpdateRepository(dir, repo, "master", nil, os.Stdout)
+	err = UpdateRepository(repo, RepoOptions{Branch: "master"}, os.Stdout)
 	assert.Nil(t, err)
-	err = UpdateRepository(dir, repo, "dev", nil, os.Stdout)
+	err = UpdateRepository(repo, RepoOptions{Branch: "dev"}, os.Stdout)
 	assert.Nil(t, err)
 }

--- a/daemon/inertiad/project/deployment.go
+++ b/daemon/inertiad/project/deployment.go
@@ -100,7 +100,6 @@ func (d *Deployment) Initialize(cfg DeploymentConfig, out io.Writer) error {
 		return errors.New("remote URL is required for first setup")
 	}
 
-	common.RemoveContents(d.directory)
 	d.SetConfig(cfg)
 
 	// Retrieve authentication

--- a/daemon/inertiad/project/deployment.go
+++ b/daemon/inertiad/project/deployment.go
@@ -114,9 +114,11 @@ func (d *Deployment) Initialize(cfg DeploymentConfig, out io.Writer) error {
 	}
 
 	// Initialize repository
-	d.repo, err = git.InitializeRepository(
-		d.directory, cfg.RemoteURL, cfg.Branch, d.auth, out,
-	)
+	d.repo, err = git.InitializeRepository(cfg.RemoteURL, git.RepoOptions{
+		Directory: d.directory,
+		Branch:    cfg.Branch,
+		Auth:      d.auth,
+	}, out)
 	return err
 }
 
@@ -151,7 +153,11 @@ func (d *Deployment) Deploy(cli *docker.Client, out io.Writer,
 
 	// Update repository
 	if !opts.SkipUpdate {
-		if err := git.UpdateRepository(d.directory, d.repo, d.branch, d.auth, out); err != nil {
+		if err := git.UpdateRepository(d.repo, git.RepoOptions{
+			Directory: d.directory,
+			Branch:    d.branch,
+			Auth:      d.auth,
+		}, out); err != nil {
 			return func() error { return nil }, err
 		}
 	}


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #350

---

## :construction_worker: Changes

* Simplify repo update function signatures
* Make repo update more aggressive with tags, submodules, etc.
* Update clone procedure to respect existing files 
* Do not clear project directory on initialization

## :flashlight: Testing Instructions

[same as usual](https://github.com/ubclaunchpad/inertia/blob/master/CONTRIBUTING.md#development-tips)
