### PR TITLE
daemon: on user create, check if error is a bad cred error and return 400

### DIFF
--- a/daemon/inertiad/auth/permissions.go
+++ b/daemon/inertiad/auth/permissions.go
@@ -216,7 +216,7 @@ func (h *PermissionsHandler) addUserHandler(w http.ResponseWriter, r *http.Reque
 	// Add user (as admin if specified)
 	if err = h.users.AddUser(userReq.Username, userReq.Password, userReq.Admin); err != nil {
 		if crypto.IsCredentialFormatError(err) {
-			http.Error(w, fmt.Sprintf("Invalid credentials: %s", err.Error()), http.StatusBadRequest)
+			http.Error(w, fmt.Sprintf("Invalid credentials format: %s", err.Error()), http.StatusBadRequest)
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/daemon/inertiad/auth/permissions.go
+++ b/daemon/inertiad/auth/permissions.go
@@ -216,7 +216,11 @@ func (h *PermissionsHandler) addUserHandler(w http.ResponseWriter, r *http.Reque
 	// Add user (as admin if specified)
 	err = h.users.AddUser(userReq.Username, userReq.Password, userReq.Admin)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		if crypto.IsCredentialFormatError(err) {
+			http.Error(w, fmt.Sprintf("Invalid credentials: %s", err.Error()), http.StatusBadRequest)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 		return
 	}
 

--- a/daemon/inertiad/auth/permissions.go
+++ b/daemon/inertiad/auth/permissions.go
@@ -214,8 +214,7 @@ func (h *PermissionsHandler) addUserHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Add user (as admin if specified)
-	err = h.users.AddUser(userReq.Username, userReq.Password, userReq.Admin)
-	if err != nil {
+	if err = h.users.AddUser(userReq.Username, userReq.Password, userReq.Admin); err != nil {
 		if crypto.IsCredentialFormatError(err) {
 			http.Error(w, fmt.Sprintf("Invalid credentials: %s", err.Error()), http.StatusBadRequest)
 		} else {

--- a/daemon/inertiad/auth/permissions_test.go
+++ b/daemon/inertiad/auth/permissions_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/pquerna/otp/totp"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/ubclaunchpad/inertia/common"
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/crypto"
@@ -435,4 +434,51 @@ func TestEnableDisableTotpEndpoints(t *testing.T) {
 	assert.Nil(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestPermissionsHandler_addUserHandler(t *testing.T) {
+	type args struct {
+		method string
+		target string
+		body   interface{}
+	}
+	type want struct {
+		status int
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{"missing body", args{"POST", "/", nil}, want{http.StatusBadRequest}},
+		{"bad credentials", args{"POST", "/", common.UserRequest{
+			Username: "bobheadxi", Password: "bobheadxi",
+		}}, want{http.StatusBadRequest}},
+		{"ok credentials", args{"POST", "/", common.UserRequest{
+			Username: "bobheadxi", Password: "bobdeadxi",
+		}}, want{http.StatusCreated}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up permission handler
+			var dir = "./test_addUserHandler"
+			ph, err := getTestPermissionsHandler(dir)
+			defer os.RemoveAll(dir)
+			assert.Nil(t, err)
+			defer ph.Close()
+
+			// test handler
+			var (
+				b, _ = json.Marshal(tt.args.body)
+				req  = httptest.NewRequest(tt.args.method, tt.args.target, bytes.NewReader(b))
+				rec  = httptest.NewRecorder()
+			)
+			ph.addUserHandler(rec, req)
+
+			// assert
+			if rec.Code != tt.want.status {
+				t.Errorf("expected status '%d', got '%d'", tt.want.status, rec.Code)
+			}
+		})
+	}
 }

--- a/daemon/inertiad/crypto/password.go
+++ b/daemon/inertiad/crypto/password.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"errors"
+	"strings"
 
 	"golang.org/x/crypto/bcrypt"
 )
@@ -11,6 +12,14 @@ var (
 	errInvalidUsername      = errors.New("Username must be at least 3 characters and only letters, numbers, underscores, and dashes are allowed")
 	errInvalidPassword      = errors.New("Password must be at least 5 characters and only letters, numbers, underscores, and dashes are allowed")
 )
+
+// IsCredentialFormatError returns true if the given error is one related to
+// username/password format
+func IsCredentialFormatError(err error) bool {
+	return strings.Contains(err.Error(), errSameUsernamePassword.Error()) ||
+		strings.Contains(err.Error(), errInvalidUsername.Error()) ||
+		strings.Contains(err.Error(), errInvalidPassword.Error())
+}
 
 // HashPassword generates a bcrypt-encrypted hash from given password
 func HashPassword(password string) (string, error) {

--- a/daemon/inertiad/crypto/password.go
+++ b/daemon/inertiad/crypto/password.go
@@ -38,6 +38,7 @@ func CorrectPassword(hash string, password string) bool {
 // ValidateCredentialValues takes a username and password and verifies
 // if they are of sufficient length and if they only contain legal characters
 func ValidateCredentialValues(username, password string) error {
+	println(username, password)
 	if username == password {
 		return errSameUsernamePassword
 	}

--- a/daemon/inertiad/crypto/password.go
+++ b/daemon/inertiad/crypto/password.go
@@ -38,7 +38,6 @@ func CorrectPassword(hash string, password string) bool {
 // ValidateCredentialValues takes a username and password and verifies
 // if they are of sufficient length and if they only contain legal characters
 func ValidateCredentialValues(username, password string) error {
-	println(username, password)
 	if username == password {
 		return errSameUsernamePassword
 	}

--- a/daemon/inertiad/crypto/password_test.go
+++ b/daemon/inertiad/crypto/password_test.go
@@ -1,10 +1,34 @@
 package crypto
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestIsCredentialFormatError(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"not credential error", args{errors.New("robert")}, false},
+		{"is credential error", args{errInvalidPassword}, true},
+		{"is credential error", args{errInvalidUsername}, true},
+		{"is credential error", args{errSameUsernamePassword}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsCredentialFormatError(tt.args.err); got != tt.want {
+				t.Errorf("IsCredentialFormatError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestHashPassword(t *testing.T) {
 	unhashed := "amazing"


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #458 

---

## :construction_worker: Changes

* Adds an error check function `IsCredentialFormatError` to check if an error is related to credential format, and returns a `400` (bad request) instead of `500`

## :flashlight: Testing Instructions

Create a user with bad credentials
