### PR TITLE
cmd: fix interactive SSH sessions

### DIFF
--- a/client/ssh_test.go
+++ b/client/ssh_test.go
@@ -23,7 +23,7 @@ func (runner *mockSSHRunner) RunStream(cmd string, interactive bool) error {
 	return nil
 }
 
-func (runner *mockSSHRunner) RunSession() error {
+func (runner *mockSSHRunner) RunSession(commands ...string) error {
 	return nil
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -94,7 +94,9 @@ Run 'inertia [remote] init' to gather this information.`,
 		user.AddCommand(deepCopy(cmdDeploymentDisableTotp))
 		cmd.AddCommand(user)
 
-		cmd.AddCommand(deepCopy(cmdDeploymentSSH))
+		ssh := deepCopy(cmdDeploymentSSH)
+		ssh.Flags().String("cmd", "", "command to execute over SSH - leave blank for terminal")
+		cmd.AddCommand(ssh)
 
 		send := deepCopy(cmdDeploymentSendFile)
 		send.Flags().StringP("dest", "d", "", "path relative from project root to send file to")
@@ -378,8 +380,10 @@ var cmdDeploymentSSH = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		command, _ := cmd.Flags().GetString("cmd")
+		commands := strings.Split(command, " ")
 		session := client.NewSSHRunner(deployment.RemoteVPS)
-		if err = session.RunSession(); err != nil {
+		if err = session.RunSession(commands...); err != nil {
 			log.Fatal(err.Error())
 		}
 	},

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -95,7 +95,7 @@ Run 'inertia [remote] init' to gather this information.`,
 		cmd.AddCommand(user)
 
 		ssh := deepCopy(cmdDeploymentSSH)
-		ssh.Flags().String("cmd", "", "command to execute over SSH - leave blank for terminal")
+		ssh.Flags().String("cmd", "/bin/sh", "command to execute over SSH")
 		cmd.AddCommand(ssh)
 
 		send := deepCopy(cmdDeploymentSendFile)
@@ -380,10 +380,8 @@ var cmdDeploymentSSH = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		command, _ := cmd.Flags().GetString("cmd")
-		commands := strings.Split(command, " ")
 		session := client.NewSSHRunner(deployment.RemoteVPS)
-		if err = session.RunSession(commands...); err != nil {
+		if err = session.RunSession(args...); err != nil {
 			log.Fatal(err.Error())
 		}
 	},


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #441 

---

## :construction_worker: Changes

Dedicated to @rwblickhan 

* reimplement SSH session run as a direct exec of `ssh`

Things now exit properly:

```
~/go/src/github.com/ubclaunchpad/inertia cmd/#441-ssh
❯ ./inertia local ssh
Welcome to Ubuntu 18.04.1 LTS (GNU/Linux 4.9.125-linuxkit x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

This system has been minimized by removing packages and content that are
not required on a system that users do not log into.

To restore this content, you can run the 'unminimize' command.
Last login: Sun Jan  6 02:11:08 2019 from 172.17.0.1
root@fe00995ac4f3:~# ^C
root@fe00995ac4f3:~# exit
logout
Connection to 127.0.0.1 closed.
2019/01/05 18:13:50 exit status 130
```

You can provide args:

```
~/go/src/github.com/ubclaunchpad/inertia cmd/#441-ssh
❯ ./inertia local ssh echo "hello world"
hello world
```

## :flashlight: Testing Instructions

```sh
make testenv
go build
./inertia init; ./inertia remote add local # follow prompts
./inertia remote set local ssh-port 69
./inertia local ssh
```
