### PR TITLE
cmd: add support for passphrase-protected PEM keys

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -68,7 +68,7 @@ func newMockSSHClient(mockRunner *mockSSHRunner) *Client {
 		version:   "test",
 		RemoteVPS: remote,
 		out:       os.Stdout,
-		sshRunner: mockRunner,
+		SSH:       mockRunner,
 	}
 }
 
@@ -90,10 +90,10 @@ func TestGetNewClient(t *testing.T) {
 	}
 	config.AddRemote(testRemote)
 
-	_, found := NewClient("tst", config)
+	_, found := NewClient("tst", "", config)
 	assert.False(t, found)
 
-	cli, found := NewClient("test", config)
+	cli, found := NewClient("test", "", config)
 	assert.True(t, found)
 	assert.Equal(t, "/some/pem/file", cli.RemoteVPS.PEM)
 	assert.Equal(t, "test", cli.version)

--- a/client/integration_test.go
+++ b/client/integration_test.go
@@ -28,7 +28,7 @@ func newIntegrationClient() *Client {
 		version:   "test",
 		RemoteVPS: remote,
 		out:       os.Stdout,
-		sshRunner: NewSSHRunner(remote),
+		SSH:       NewSSHRunner(remote, ""),
 	}
 }
 

--- a/client/ssh.go
+++ b/client/ssh.go
@@ -23,28 +23,32 @@ type SSHSession interface {
 
 // SSHRunner runs commands over SSH and captures results.
 type SSHRunner struct {
-	pem     string
 	user    string
 	ip      string
 	sshPort string
+
+	pemPath       string
+	pemPassphrase string
 }
 
 // NewSSHRunner returns a new SSHRunner
-func NewSSHRunner(r *cfg.RemoteVPS) *SSHRunner {
+func NewSSHRunner(r *cfg.RemoteVPS, keyPassphrase string) *SSHRunner {
 	if r != nil {
 		return &SSHRunner{
-			pem:     r.PEM,
 			user:    r.User,
 			ip:      r.IP,
 			sshPort: r.SSHPort,
+
+			pemPath:       r.PEM,
+			pemPassphrase: keyPassphrase,
 		}
 	}
 	return &SSHRunner{}
 }
 
 // Run runs a command remotely.
-func (runner *SSHRunner) Run(cmd string) (cmdout *bytes.Buffer, cmderr *bytes.Buffer, err error) {
-	session, err := getSSHSession(runner.pem, runner.ip, runner.sshPort, runner.user)
+func (r *SSHRunner) Run(cmd string) (cmdout *bytes.Buffer, cmderr *bytes.Buffer, err error) {
+	session, err := getSSHSession(r.pemPath, r.ip, r.sshPort, r.user, r.pemPassphrase)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,8 +66,8 @@ func (runner *SSHRunner) Run(cmd string) (cmdout *bytes.Buffer, cmderr *bytes.Bu
 
 // RunStream remotely executes given command, streaming its output
 // and opening up an optionally interactive session
-func (runner *SSHRunner) RunStream(cmd string, interactive bool) error {
-	session, err := getSSHSession(runner.pem, runner.ip, runner.sshPort, runner.user)
+func (r *SSHRunner) RunStream(cmd string, interactive bool) error {
+	session, err := getSSHSession(r.pemPath, r.ip, r.sshPort, r.user, r.pemPassphrase)
 	if err != nil {
 		return err
 	}
@@ -81,8 +85,8 @@ func (runner *SSHRunner) RunStream(cmd string, interactive bool) error {
 }
 
 // RunSession sets up a SSH shell to the remote
-func (runner *SSHRunner) RunSession() error {
-	session, err := getSSHSession(runner.pem, runner.ip, runner.sshPort, runner.user)
+func (r *SSHRunner) RunSession() error {
+	session, err := getSSHSession(r.pemPath, r.ip, r.sshPort, r.user, r.pemPassphrase)
 	if err != nil {
 		return err
 	}
@@ -119,7 +123,7 @@ func (runner *SSHRunner) RunSession() error {
 }
 
 // CopyFile copies given reader to remote
-func (runner *SSHRunner) CopyFile(file io.Reader, remotePath string, permissions string) error {
+func (r *SSHRunner) CopyFile(file io.Reader, remotePath string, permissions string) error {
 	// Open and read file
 	contents, err := ioutil.ReadAll(file)
 	if err != nil {
@@ -130,7 +134,7 @@ func (runner *SSHRunner) CopyFile(file io.Reader, remotePath string, permissions
 	// Set up
 	filename := filepath.Base(remotePath)
 	directory := filepath.Dir(remotePath)
-	session, err := getSSHSession(runner.pem, runner.ip, runner.sshPort, runner.user)
+	session, err := getSSHSession(r.pemPath, r.ip, r.sshPort, r.user, r.pemPassphrase)
 	if err != nil {
 		return err
 	}
@@ -149,13 +153,13 @@ func (runner *SSHRunner) CopyFile(file io.Reader, remotePath string, permissions
 }
 
 // Stubbed out for testing.
-func getSSHSession(PEM, IP, sshPort, user string) (*ssh.Session, error) {
+func getSSHSession(PEM, IP, sshPort, user, passphrase string) (*ssh.Session, error) {
 	privateKey, err := ioutil.ReadFile(PEM)
 	if err != nil {
 		return nil, err
 	}
 
-	cfg, err := getSSHConfig(privateKey, user)
+	cfg, err := getSSHConfig(privateKey, user, passphrase)
 	if err != nil {
 		return nil, err
 	}
@@ -170,10 +174,17 @@ func getSSHSession(PEM, IP, sshPort, user string) (*ssh.Session, error) {
 }
 
 // getSSHConfig returns SSH configuration for the remote.
-func getSSHConfig(privateKey []byte, user string) (*ssh.ClientConfig, error) {
-	key, err := ssh.ParsePrivateKey(privateKey)
-	if err != nil {
-		return nil, err
+func getSSHConfig(privateKey []byte, user, passphrase string) (*ssh.ClientConfig, error) {
+	var key ssh.Signer
+	var err error
+	if passphrase == "" {
+		if key, err = ssh.ParsePrivateKey(privateKey); err != nil {
+			return nil, fmt.Errorf("failed to parse key without passphrase: %s", err.Error())
+		}
+	} else {
+		if key, err = ssh.ParsePrivateKeyWithPassphrase(privateKey, []byte(passphrase)); err != nil {
+			return nil, fmt.Errorf("failed to parse key with passphrase: %s", err.Error())
+		}
 	}
 
 	// Authentication

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ubclaunchpad/inertia/local"
 
 	"github.com/spf13/cobra"
-	"github.com/ubclaunchpad/inertia/client"
 )
 
 // parseConfigArg is a dirty dirty hack to allow access to the --config argument
@@ -61,6 +60,8 @@ Requires:
 2. a deploy key to be registered within your remote repository for the daemon to use.
 
 Continuous deployment requires the daemon's webhook address to be registered in your remote repository.
+
+If the SSH key for your remote requires a passphrase, it can be provided via 'PEM_PASSPHRASE'.
 
 Run 'inertia [remote] init' to gather this information.`,
 		}
@@ -378,8 +379,7 @@ var cmdDeploymentSSH = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		session := client.NewSSHRunner(deployment.RemoteVPS)
-		if err = session.RunSession(); err != nil {
+		if err = deployment.SSH.RunSession(); err != nil {
 			log.Fatal(err.Error())
 		}
 	},
@@ -427,8 +427,7 @@ var cmdDeploymentSendFile = &cobra.Command{
 		remotePath := path.Join(projectPath, dest)
 
 		// Initiate copy
-		session := client.NewSSHRunner(deployment.RemoteVPS)
-		err = session.CopyFile(f, remotePath, permissions)
+		err = deployment.SSH.CopyFile(f, remotePath, permissions)
 		if err != nil {
 			log.Fatal(err.Error())
 		}

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -165,7 +165,7 @@ This ensures that your project ports are properly exposed and externally accessi
 		config.Write(path)
 
 		// Create inertia client
-		inertia, found := client.NewClient(args[0], config, os.Stdout)
+		inertia, found := client.NewClient(args[0], os.Getenv(local.EnvSSHPassphrase), config, os.Stdout)
 		if !found {
 			log.Fatal("vps setup did not complete properly")
 		}

--- a/local/env.go
+++ b/local/env.go
@@ -1,0 +1,6 @@
+package local
+
+const (
+	// EnvSSHPassphrase is the key used to fetch PEM key passphrases
+	EnvSSHPassphrase = "PEM_PASSPHRASE"
+)

--- a/local/storage.go
+++ b/local/storage.go
@@ -94,7 +94,7 @@ func GetClient(name, relPath string, cmd ...*cobra.Command) (*client.Client, fun
 		return nil, nil, err
 	}
 
-	client, found := client.NewClient(name, config, os.Stdout)
+	client, found := client.NewClient(name, os.Getenv(EnvSSHPassphrase), config, os.Stdout)
 	if !found {
 		return nil, nil, errors.New("Remote not found")
 	}


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #408

---

## :construction_worker: Changes

This PR adds support for passphrase-protected keys via the `PEM_PASSPHRASE` environment variable

## :flashlight: Testing Instructions

set env, try to use a passphrase-protected key
