### PR TITLE
cmd: use flag key variables instead of plain strings

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -88,6 +88,7 @@ func (root *ConfigCmd) attachSetCmd() {
 }
 
 func (root *ConfigCmd) attachUpgradeCmd() {
+	const flagVersion = "version"
 	var upgrade = &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrade your Inertia configuration version to match the CLI",
@@ -100,7 +101,7 @@ func (root *ConfigCmd) attachUpgradeCmd() {
 			}
 
 			var version = root.Version
-			if v, _ := cmd.Flags().GetString("version"); v != "" {
+			if v, _ := cmd.Flags().GetString(flagVersion); v != "" {
 				version = v
 			}
 
@@ -111,6 +112,6 @@ func (root *ConfigCmd) attachUpgradeCmd() {
 			}
 		},
 	}
-	upgrade.Flags().String("version", root.Version, "specify Inertia daemon version to set")
+	upgrade.Flags().String(flagVersion, root.Version, "specify Inertia daemon version to set")
 	root.AddCommand(upgrade)
 }

--- a/cmd/host/env.go
+++ b/cmd/host/env.go
@@ -42,6 +42,7 @@ as follows:
 }
 
 func (root *EnvCmd) attachSetCmd() {
+	const flagEncrypt = "encrypt"
 	var set = &cobra.Command{
 		Use:   "set [name] [value]",
 		Short: "Set an environment variable on your remote",
@@ -49,7 +50,7 @@ func (root *EnvCmd) attachSetCmd() {
 variables are applied to all deployed containers.`,
 		Args: cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			var encrypt, _ = cmd.Flags().GetBool("encrypt")
+			var encrypt, _ = cmd.Flags().GetBool(flagEncrypt)
 			resp, err := root.host.client.UpdateEnv(args[0], args[1], encrypt, false)
 			if err != nil {
 				printutil.Fatal(err)
@@ -62,7 +63,7 @@ variables are applied to all deployed containers.`,
 			fmt.Printf("(Status code %d) %s\n", resp.StatusCode, body)
 		},
 	}
-	set.Flags().BoolP("encrypt", "e", false, "encrypt variable when stored")
+	set.Flags().BoolP(flagEncrypt, "e", false, "encrypt variable when stored")
 	root.AddCommand(set)
 }
 

--- a/cmd/host/user.go
+++ b/cmd/host/user.go
@@ -42,6 +42,7 @@ func AttachUserCmd(host *HostCmd) {
 }
 
 func (root *UserCmd) attachAddCmd() {
+	const flagAdmin = "admin"
 	var add = &cobra.Command{
 		Use:   "add [user]",
 		Short: "Create a user with access to this remote's Inertia daemon",
@@ -61,7 +62,7 @@ Use the --admin flag to create an admin user.`,
 			var password = strings.TrimSpace(string(bytePassword))
 			fmt.Print("\n")
 
-			var admin, _ = cmd.Flags().GetBool("admin")
+			var admin, _ = cmd.Flags().GetBool(flagAdmin)
 			resp, err := root.host.client.AddUser(args[0], password, admin)
 			if err != nil {
 				printutil.Fatal(err)
@@ -83,7 +84,7 @@ Use the --admin flag to create an admin user.`,
 			}
 		},
 	}
-	add.Flags().Bool("admin", false, "create a user with administrator permissions")
+	add.Flags().Bool(flagAdmin, false, "create a user with administrator permissions")
 	root.AddCommand(add)
 }
 

--- a/cmd/remote/remote.go
+++ b/cmd/remote/remote.go
@@ -64,6 +64,10 @@ inertia gcloud status      # check on status of Inertia daemon
 }
 
 func (root *RemoteCmd) attachAddCmd() {
+	const (
+		flagPort    = "port"
+		flagSSHPort = "ssh.port"
+	)
 	var addRemote = &cobra.Command{
 		Use:   "add [remote]",
 		Short: "Add a reference to a remote VPS instance",
@@ -76,8 +80,8 @@ Inertia commands.`,
 				printutil.Fatal(errors.New("Remote " + args[0] + " already exists."))
 			}
 
-			var port, _ = cmd.Flags().GetString("port")
-			var sshPort, _ = cmd.Flags().GetString("ssh.port")
+			var port, _ = cmd.Flags().GetString(flagPort)
+			var sshPort, _ = cmd.Flags().GetString(flagSSHPort)
 			branch, err := local.GetRepoCurrentBranch()
 			if err != nil {
 				printutil.Fatal(err)
@@ -98,18 +102,19 @@ Inertia commands.`,
 			fmt.Println("for continuous deployment.")
 		},
 	}
-	addRemote.Flags().StringP("port", "p", "4303", "remote daemon port")
-	addRemote.Flags().StringP("ssh.port", "s", "22", "remote SSH port")
+	addRemote.Flags().StringP(flagPort, "p", "4303", "remote daemon port")
+	addRemote.Flags().StringP(flagSSHPort, "s", "22", "remote SSH port")
 	root.AddCommand(addRemote)
 }
 
 func (root *RemoteCmd) attachListCmd() {
+	const flagVerbose = "verbose"
 	var list = &cobra.Command{
 		Use:   "ls",
 		Short: "List currently configured remotes",
 		Long:  `Lists all currently configured remotes.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			var verbose, _ = cmd.Flags().GetBool("verbose")
+			var verbose, _ = cmd.Flags().GetBool(flagVerbose)
 			for name, remote := range root.config.Remotes {
 				if remote != nil && verbose {
 					fmt.Println(printutil.FormatRemoteDetails(remote))
@@ -119,7 +124,7 @@ func (root *RemoteCmd) attachListCmd() {
 			}
 		},
 	}
-	list.Flags().BoolP("verbose", "v", false, "enable verbose output")
+	list.Flags().BoolP(flagVerbose, "v", false, "enable verbose output")
 	root.AddCommand(list)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,6 +71,7 @@ Issue tracker: https://github.com/ubclaunchpad/inertia/issues`,
 }
 
 func attachInitCmd(inertia *inertiacmd.Cmd) {
+	const flagVersion = "version"
 	var init = &cobra.Command{
 		Use:   "init",
 		Short: "Initialize an Inertia project in this repository",
@@ -79,7 +80,7 @@ func attachInitCmd(inertia *inertiacmd.Cmd) {
 		to succeed.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			version := cmd.Parent().Version
-			givenVersion, err := cmd.Flags().GetString("version")
+			givenVersion, err := cmd.Flags().GetString(flagVersion)
 			if err != nil {
 				printutil.Fatal(err)
 			}
@@ -125,6 +126,6 @@ func attachInitCmd(inertia *inertiacmd.Cmd) {
 			println("VPS instance.")
 		},
 	}
-	init.Flags().String("version", inertia.Version, "specify Inertia daemon version to use")
+	init.Flags().String(flagVersion, inertia.Version, "specify Inertia daemon version to use")
 	inertia.AddCommand(init)
 }


### PR DESCRIPTION
:tickets: **Ticket(s)**: n/a

---

## :construction_worker: Changes

Replaces direct string key retrieval with variables denoting flag keys

## :flashlight: Testing Instructions

all commands should work as before
