### PR TITLE
provision: fix default aws credentials path

### DIFF
--- a/cmd/provision/provision.go
+++ b/cmd/provision/provision.go
@@ -209,8 +209,8 @@ This ensures that your project ports are properly exposed and externally accessi
 		"load ec2 credentials from environment - requires AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY to be set")
 	provEC2.Flags().Bool(flagFromProfile, false,
 		"load ec2 credentials from profile")
-	provEC2.Flags().String(flagProfilePath, "~/.aws/config",
-		"path to aws profile configuration file")
+	provEC2.Flags().String(flagProfilePath, "~/.aws/credentials",
+		"path to aws profile credentials file")
 	provEC2.Flags().String(flagProfileUser, "default",
 		"user profile for aws credentials file")
 


### PR DESCRIPTION
:tickets: **Ticket(s)**: n/a

---

## :construction_worker: Changes

The default profile path was incorrect

## :flashlight: Testing Instructions

set up credentials in `~/.aws/credentials` (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)

```
inertia provision ec2 --from-profile blah
```

region listing should work as authentication is used
