### PR TITLE
daemon: JSON responses for API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -167,6 +167,25 @@
   version = "v1.12.0"
 
 [[projects]]
+  digest = "1:9883e4bc6a4b3e0c2266ff322ccfcdf5566d11c889160fe798589a4633edc871"
+  name = "github.com/go-chi/chi"
+  packages = [
+    ".",
+    "middleware",
+  ]
+  pruneopts = "NUT"
+  revision = "1a6bb108ccf279c8dac6f9bad857d773b4f9b421"
+  version = "v4.0.1"
+
+[[projects]]
+  digest = "1:c831043316efe18a5b81f75568c0de847645e127cac35082c68de5b4b417d18f"
+  name = "github.com/go-chi/cors"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "dba6525398619dead495962a916728e7ee2ca322"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:8ba832f19021187b30cf505ea0335c1b779b378e61c2468790082f7262925c4d"
   name = "github.com/gogo/protobuf"
   packages = ["proto"]
@@ -521,6 +540,9 @@
     "github.com/docker/docker/api/types/filters",
     "github.com/docker/docker/client",
     "github.com/docker/go-connections/nat",
+    "github.com/go-chi/chi",
+    "github.com/go-chi/chi/middleware",
+    "github.com/go-chi/cors",
     "github.com/gorilla/websocket",
     "github.com/pquerna/otp",
     "github.com/pquerna/otp/totp",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -186,6 +186,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:6982473e328c7049bdc425618872e37609d4bc58dc4198f4dcbe7cf64ca7b7f0"
+  name = "github.com/go-chi/render"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "3215478343fbc559bd3fc08f7031bb134d6bdad5"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:8ba832f19021187b30cf505ea0335c1b779b378e61c2468790082f7262925c4d"
   name = "github.com/gogo/protobuf"
   packages = ["proto"]
@@ -543,6 +551,7 @@
     "github.com/go-chi/chi",
     "github.com/go-chi/chi/middleware",
     "github.com/go-chi/cors",
+    "github.com/go-chi/render",
     "github.com/gorilla/websocket",
     "github.com/pquerna/otp",
     "github.com/pquerna/otp/totp",

--- a/api/api.go
+++ b/api/api.go
@@ -14,6 +14,22 @@ const (
 	Entries = "entries"
 )
 
+// BaseResponse is the underlying response structure to all responses
+type BaseResponse struct {
+	// Basic metadata
+	HTTPStatusCode int    `json:"code"`
+	RequestID      string `json:"request_id,omitempty"`
+
+	// Message is included in all responses, and is a summary of the server's response
+	Message string `json:"message"`
+
+	// Error contains additional context in the event of an error
+	Error string `json:"error,omitempty"`
+
+	// Data contains information the server wants to return
+	Data map[string]interface{} `json:"data,omitempty"`
+}
+
 // UpRequest is the configurable body of a UP request to the daemon.
 type UpRequest struct {
 	Stream        bool       `json:"stream"`

--- a/api/api.go
+++ b/api/api.go
@@ -14,22 +14,6 @@ const (
 	Entries = "entries"
 )
 
-// BaseResponse is the underlying response structure to all responses
-type BaseResponse struct {
-	// Basic metadata
-	HTTPStatusCode int    `json:"code"`
-	RequestID      string `json:"request_id,omitempty"`
-
-	// Message is included in all responses, and is a summary of the server's response
-	Message string `json:"message"`
-
-	// Error contains additional context in the event of an error
-	Error string `json:"error,omitempty"`
-
-	// Data contains information the server wants to return
-	Data map[string]interface{} `json:"data,omitempty"`
-}
-
 // UpRequest is the configurable body of a UP request to the daemon.
 type UpRequest struct {
 	Stream        bool       `json:"stream"`
@@ -55,12 +39,6 @@ type UserRequest struct {
 	Totp     string `json:"totp"`
 }
 
-// TotpResponse is used for sending users their Totp secret and backup codes
-type TotpResponse struct {
-	TotpSecret  string   `json:"secret"`
-	BackupCodes []string `json:"backup_codes"`
-}
-
 // EnvRequest represents a request to manage environment variables
 type EnvRequest struct {
 	Name    string `json:"name,omitempty"`
@@ -68,15 +46,4 @@ type EnvRequest struct {
 	Encrypt bool   `json:"encrypt,omitempty"`
 
 	Remove bool `json:"remove,omitempty"`
-}
-
-// DeploymentStatus lists details about the deployed project
-type DeploymentStatus struct {
-	InertiaVersion       string   `json:"version"`
-	Branch               string   `json:"branch"`
-	CommitHash           string   `json:"commit_hash"`
-	CommitMessage        string   `json:"commit_message"`
-	BuildType            string   `json:"build_type"`
-	Containers           []string `json:"containers"`
-	BuildContainerActive bool     `json:"build_active"`
 }

--- a/api/api.go
+++ b/api/api.go
@@ -41,8 +41,8 @@ type UserRequest struct {
 
 // TotpResponse is used for sending users their Totp secret and backup codes
 type TotpResponse struct {
-	TotpSecret  string `json:"key"`
-	BackupCodes []string
+	TotpSecret  string   `json:"secret"`
+	BackupCodes []string `json:"backup_codes"`
 }
 
 // EnvRequest represents a request to manage environment variables

--- a/api/response.go
+++ b/api/response.go
@@ -37,6 +37,8 @@ type KV struct {
 // 	  var totpResp = &api.TotpResponse{}
 //    api.Unmarshal(resp.Body, api.KV{Key: "totp", Value: totpResp})
 //
+// Values provided in KV.Value MUST be explicit pointers, even if the value is
+// a pointer type, ie maps and slices.
 func Unmarshal(r io.Reader, kvs ...KV) (*BaseResponse, error) {
 	bytes, err := ioutil.ReadAll(r)
 	if err != nil {
@@ -47,7 +49,7 @@ func Unmarshal(r io.Reader, kvs ...KV) (*BaseResponse, error) {
 	// map to preserve raw JSON data in the keys
 	var (
 		data = make(map[string]json.RawMessage)
-		resp = BaseResponse{Data: data}
+		resp = BaseResponse{Data: &data}
 	)
 	if err := json.Unmarshal(bytes, &resp); err != nil {
 		return nil, fmt.Errorf("could not unmarshal data from reader: %s", err.Error())

--- a/api/response.go
+++ b/api/response.go
@@ -69,9 +69,9 @@ func (b *BaseResponse) Error() error {
 		return nil
 	}
 	if b.Err == "" {
-		return fmt.Errorf("error status %d: %s", b.HTTPStatusCode, b.Message)
+		return fmt.Errorf("[error %d] %s", b.HTTPStatusCode, b.Message)
 	}
-	return fmt.Errorf("error stats %d: %s (%s)", b.HTTPStatusCode, b.Message, b.Err)
+	return fmt.Errorf("[error %d] %s: (%s)", b.HTTPStatusCode, b.Message, b.Err)
 }
 
 // TotpResponse is used for sending users their Totp secret and backup codes

--- a/api/response.go
+++ b/api/response.go
@@ -34,7 +34,7 @@ type KV struct {
 // For example:
 //
 // 	  var totpResp = &api.TotpResponse{}
-//    api.Unmarshal(resp.Body, api.KeyValue{Key: "totp", Value: totpResp})
+//    api.Unmarshal(resp.Body, api.KV{Key: "totp", Value: totpResp})
 //
 func Unmarshal(r io.Reader, kvs ...KV) (*BaseResponse, error) {
 	bytes, err := ioutil.ReadAll(r)

--- a/api/response.go
+++ b/api/response.go
@@ -1,0 +1,35 @@
+package api
+
+// BaseResponse is the underlying response structure to all responses.
+type BaseResponse struct {
+	// Basic metadata
+	HTTPStatusCode int    `json:"code"`
+	RequestID      string `json:"request_id,omitempty"`
+
+	// Message is included in all responses, and is a summary of the server's response
+	Message string `json:"message"`
+
+	// Error contains additional context in the event of an error
+	Error string `json:"error,omitempty"`
+
+	// Data contains information the server wants to return
+	// To parse data into a particular type, you can
+	Data map[string]interface{} `json:"data,omitempty"`
+}
+
+// TotpResponse is used for sending users their Totp secret and backup codes
+type TotpResponse struct {
+	TotpSecret  string   `json:"secret"`
+	BackupCodes []string `json:"backup_codes"`
+}
+
+// DeploymentStatus lists details about the deployed project
+type DeploymentStatus struct {
+	InertiaVersion       string   `json:"version"`
+	Branch               string   `json:"branch"`
+	CommitHash           string   `json:"commit_hash"`
+	CommitMessage        string   `json:"commit_message"`
+	BuildType            string   `json:"build_type"`
+	Containers           []string `json:"containers"`
+	BuildContainerActive bool     `json:"build_active"`
+}

--- a/api/response_test.go
+++ b/api/response_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestUnmarshal(t *testing.T) {
+	type args struct {
+		bytes []byte
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantCode int
+		wantErr  bool
+	}{
+		{"invalid data",
+			args{nil},
+			0,
+			true},
+		{"invalid json",
+			args{
+				[]byte(`{
+				"code":200,
+				"request_id":"bobbook/2Mch7LMzhj-000001",
+				"mess`),
+			},
+			0,
+			true},
+		{"ok",
+			args{
+				[]byte(`{
+					"code":200,
+					"request_id":"bobbook/2Mch7LMzhj-000001",
+					"message":"session created",
+					"data":{
+						"token":"blah"
+					}
+				}`),
+			},
+			200,
+			false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotToken string
+			var gotKV = []KV{{Key: "token", Value: &gotToken}}
+			got, err := Unmarshal(bytes.NewReader(tt.args.bytes), gotKV...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil && tt.wantCode != got.HTTPStatusCode {
+				t.Errorf("Unmarshal() code = %v, want %v", got.HTTPStatusCode, tt.wantCode)
+			}
+			for _, kv := range gotKV {
+				if kv.Value == "" {
+					t.Error("Unmarshal() kv is empty")
+				}
+			}
+		})
+	}
+}
+
+func TestBaseResponse_Error(t *testing.T) {
+	type fields struct {
+		HTTPStatusCode int
+		Message        string
+		Err            string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{"not an error",
+			fields{200, "hi", ""},
+			false},
+		{"error with only message",
+			fields{400, "hi", ""},
+			true},
+		{"error with message and error context",
+			fields{400, "hi", "oh no"},
+			true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &BaseResponse{
+				HTTPStatusCode: tt.fields.HTTPStatusCode,
+				Message:        tt.fields.Message,
+				Err:            tt.fields.Err,
+			}
+			if err := b.Error(); (err != nil) != tt.wantErr {
+				t.Errorf("BaseResponse.Error() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/host/env.go
+++ b/cmd/host/env.go
@@ -105,7 +105,7 @@ variables are not be decrypted.`,
 				printutil.Fatal(err)
 			}
 			defer resp.Body.Close()
-			var variables []string
+			var variables = make([]string, 0)
 			b, err := api.Unmarshal(resp.Body, api.KV{Key: "variables", Value: &variables})
 			if err != nil {
 				printutil.Fatal(err)

--- a/cmd/host/env.go
+++ b/cmd/host/env.go
@@ -3,8 +3,10 @@ package hostcmd
 import (
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/ubclaunchpad/inertia/api"
 	"github.com/ubclaunchpad/inertia/cmd/printutil"
 )
 
@@ -103,11 +105,13 @@ variables are not be decrypted.`,
 				printutil.Fatal(err)
 			}
 			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
+			var variables []string
+			b, err := api.Unmarshal(resp.Body, api.KV{Key: "variables", Value: &variables})
 			if err != nil {
 				printutil.Fatal(err)
 			}
-			fmt.Printf("(Status code %d) %s\n", resp.StatusCode, body)
+			fmt.Printf("(Status code %d) %s: \n%s\n",
+				resp.StatusCode, b.Message, strings.Join(variables, "\n"))
 		},
 	}
 	root.AddCommand(list)

--- a/cmd/host/env.go
+++ b/cmd/host/env.go
@@ -110,8 +110,12 @@ variables are not be decrypted.`,
 			if err != nil {
 				printutil.Fatal(err)
 			}
-			fmt.Printf("(Status code %d) %s: \n%s\n",
-				resp.StatusCode, b.Message, strings.Join(variables, "\n"))
+			if len(variables) == 0 {
+				fmt.Printf("(Status code %d) no variables configured", resp.StatusCode)
+			} else {
+				fmt.Printf("(Status code %d) %s: \n%s\n",
+					resp.StatusCode, b.Message, strings.Join(variables, "\n"))
+			}
 		},
 	}
 	root.AddCommand(list)

--- a/cmd/host/host.go
+++ b/cmd/host/host.go
@@ -2,12 +2,12 @@ package hostcmd
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/ubclaunchpad/inertia/client"
 	inertiacmd "github.com/ubclaunchpad/inertia/cmd/cmd"
@@ -228,7 +228,9 @@ Requires the Inertia daemon to be active on your remote - do this by running 'in
 				fmt.Printf("(Status code %d) Daemon at remote '%s' online at %s\n",
 					resp.StatusCode, root.client.Name, host)
 				var status = &api.DeploymentStatus{}
-				if err := json.NewDecoder(resp.Body).Decode(status); err != nil {
+				if _, err := api.Unmarshal(resp.Body, api.KV{
+					Key: "status", Value: status,
+				}); err != nil {
 					printutil.Fatal(err)
 				}
 				println(printutil.FormatStatus(status))
@@ -279,20 +281,22 @@ Use 'inertia [remote] status' to see which containers are active.`,
 				}
 				defer resp.Body.Close()
 
-				body, err := ioutil.ReadAll(resp.Body)
+				var logs []string
+				b, err := api.Unmarshal(resp.Body, api.KV{Key: "logs", Value: &logs})
 				if err != nil {
 					printutil.Fatal(err)
 				}
+
 				switch resp.StatusCode {
 				case http.StatusOK:
-					fmt.Printf("(Status code %d) Logs: \n%s\n", resp.StatusCode, body)
+					fmt.Printf("(Status code %d) Logs: \n%s\n", resp.StatusCode, strings.Join(logs, "\n"))
 				case http.StatusUnauthorized:
-					fmt.Printf("(Status code %d) Bad auth:\n%s\n", resp.StatusCode, body)
+					fmt.Printf("(Status code %d) Bad auth:\n%s\n", resp.StatusCode, b.Message)
 				case http.StatusPreconditionFailed:
-					fmt.Printf("(Status code %d) Problem with deployment setup:\n%s\n", resp.StatusCode, body)
+					fmt.Printf("(Status code %d) Problem with deployment setup:\n%s\n", resp.StatusCode, b.Message)
 				default:
 					fmt.Printf("(Status code %d) Unknown response from daemon:\n%s\n",
-						resp.StatusCode, body)
+						resp.StatusCode, b.Message)
 				}
 			} else {
 				// if not short, open a websocket to stream logs
@@ -507,19 +511,20 @@ func (root *HostCmd) attachTokenCmd() {
 			}
 			defer resp.Body.Close()
 
-			body, err := ioutil.ReadAll(resp.Body)
+			var token string
+			b, err := api.Unmarshal(resp.Body, api.KV{Key: "token", Value: &token})
 			if err != nil {
 				printutil.Fatal(err)
 			}
 
 			switch resp.StatusCode {
 			case http.StatusOK:
-				fmt.Printf("New token: %s\n", string(body))
+				fmt.Printf("New token: %s\n", token)
 			case http.StatusUnauthorized:
-				fmt.Printf("(Status code %d) Bad auth:\n%s\n", resp.StatusCode, string(body))
+				fmt.Printf("(Status code %d) Bad auth:\n%s\n", resp.StatusCode, b.Message)
 			default:
 				fmt.Printf("(Status code %d) Unknown response from daemon:\n%s\n",
-					resp.StatusCode, body)
+					resp.StatusCode, b.Message)
 			}
 		},
 	}

--- a/cmd/host/user.go
+++ b/cmd/host/user.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
+	"github.com/ubclaunchpad/inertia/api"
 	"github.com/ubclaunchpad/inertia/cmd/printutil"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -162,8 +163,8 @@ func (root *UserCmd) attachLoginCmd() {
 				return
 			}
 			defer resp.Body.Close()
-			token, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
+			var token string
+			if api.Unmarshal(resp.Body, api.KV{Key: "token", Value: &token}); err != nil {
 				printutil.Fatal(err)
 			}
 

--- a/cmd/host/user.go
+++ b/cmd/host/user.go
@@ -171,7 +171,6 @@ func (root *UserCmd) attachLoginCmd() {
 			var config = root.host.config
 			var remote = root.host.remote
 			config.Remotes[remote].Daemon.Token = string(token)
-			config.Remotes[remote].User = username
 			if err = config.Write(root.host.cfgPath); err != nil {
 				printutil.Fatal(err)
 			}

--- a/cmd/host/user.go
+++ b/cmd/host/user.go
@@ -226,18 +226,22 @@ func (root *UserCmd) attachListCmd() {
 				printutil.Fatal(err)
 			}
 			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
+
+			var users = make([]string, 0)
+			b, err := api.Unmarshal(resp.Body, api.KV{Key: "users", Value: &users})
 			if err != nil {
 				printutil.Fatal(err)
 			}
+
 			switch resp.StatusCode {
 			case http.StatusOK:
-				fmt.Printf("(Status code %d) %s\n", resp.StatusCode, body)
+				fmt.Printf("(Status code %d) %s:\n%s", resp.StatusCode, b.Message,
+					strings.Join(users, "\n"))
 			case http.StatusUnauthorized:
-				fmt.Printf("(Status code %d) Bad auth:\n%s\n", resp.StatusCode, body)
+				fmt.Printf("(Status code %d) Bad auth: %s\n", resp.StatusCode, b.Error())
 			default:
-				fmt.Printf("(Status code %d) Unknown response from daemon:\n%s\n",
-					resp.StatusCode, body)
+				fmt.Printf("(Status code %d) Unknown response from daemon: %s\n",
+					resp.StatusCode, b.Error())
 			}
 		},
 	}

--- a/cmd/host/user_totp.go
+++ b/cmd/host/user_totp.go
@@ -1,9 +1,7 @@
 package hostcmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"syscall"
 
@@ -65,13 +63,10 @@ func (root *UserTotpCmd) attachEnableCmd() {
 				return
 			}
 			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				printutil.Fatal(err)
-			}
 
 			var totpInfo api.TotpResponse
-			if err = json.Unmarshal(body, &totpInfo); err != nil {
+			b, err := api.Unmarshal(resp.Body, api.KV{Key: "totp", Value: &totpInfo})
+			if err != nil {
 				printutil.Fatal(err)
 			}
 
@@ -80,8 +75,8 @@ func (root *UserTotpCmd) attachEnableCmd() {
 			qr.New().Get(fmt.Sprintf("otpauth://totp/%s?secret=%s&issuer=Inertia",
 				username, totpInfo.TotpSecret)).Print()
 
-			fmt.Printf("\n\n(Status code %d) TOTP successfully enabled.\n",
-				resp.StatusCode)
+			fmt.Printf("\n\n(Status code %d) %s\n",
+				resp.StatusCode, b.Message)
 			fmt.Print("Scan the QR code above to " +
 				"add your Inertia account to your authenticator app.\n\n")
 			fmt.Printf("Your secret key is: %s\n", totpInfo.TotpSecret)

--- a/daemon/inertiad/auth/permissions.go
+++ b/daemon/inertiad/auth/permissions.go
@@ -186,34 +186,45 @@ func (h *PermissionsHandler) AttachPublicHandler(path string, handler http.Handl
 }
 
 // AttachPublicHandlerFunc attaches given path and handler and makes it publicly available
-func (h *PermissionsHandler) AttachPublicHandlerFunc(path string, handler http.HandlerFunc) {
-	h.mux.HandleFunc(path, handler)
+func (h *PermissionsHandler) AttachPublicHandlerFunc(
+	path string,
+	handler http.HandlerFunc,
+	methods ...string,
+) {
+	h.register(path, handler, methods)
 }
 
 // AttachUserRestrictedHandlerFunc attaches and restricts given path and handler to logged in users.
-func (h *PermissionsHandler) AttachUserRestrictedHandlerFunc(path string,
-	handler http.HandlerFunc, methods ...string) {
+func (h *PermissionsHandler) AttachUserRestrictedHandlerFunc(
+	path string,
+	handler http.HandlerFunc,
+	methods ...string,
+) {
 	h.userPaths = append(h.userPaths, path)
-	for _, m := range methods {
-		switch m {
-		case http.MethodGet:
-			h.mux.Get(path, handler)
-		case http.MethodPost:
-			h.mux.Post(path, handler)
-		}
-	}
+	h.register(path, handler, methods)
 }
 
 // AttachAdminRestrictedHandlerFunc attaches and restricts given path and handler to logged in admins.
-func (h *PermissionsHandler) AttachAdminRestrictedHandlerFunc(path string,
-	handler http.HandlerFunc, methods ...string) {
+func (h *PermissionsHandler) AttachAdminRestrictedHandlerFunc(
+	path string,
+	handler http.HandlerFunc,
+	methods ...string,
+) {
 	h.adminPaths = append(h.adminPaths, path)
-	for _, m := range methods {
-		switch m {
-		case http.MethodGet:
-			h.mux.Get(path, handler)
-		case http.MethodPost:
-			h.mux.Post(path, handler)
+	h.register(path, handler, methods)
+}
+
+func (h *PermissionsHandler) register(path string, handler http.HandlerFunc, methods []string) {
+	if len(methods) == 0 {
+		h.mux.HandleFunc(path, handler)
+	} else {
+		for _, m := range methods {
+			switch m {
+			case http.MethodGet:
+				h.mux.Get(path, handler)
+			case http.MethodPost:
+				h.mux.Post(path, handler)
+			}
 		}
 	}
 }

--- a/daemon/inertiad/auth/sessions.go
+++ b/daemon/inertiad/auth/sessions.go
@@ -8,9 +8,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/ubclaunchpad/inertia/common"
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/crypto"
+)
+
+var (
+	errSessionNotFound = errors.New("session not found")
+	errMalformedHeader = errors.New("authorization is malformed")
 )
 
 type sessionManager struct {
@@ -119,7 +124,7 @@ func (s *sessionManager) GetSession(r *http.Request) (*crypto.TokenClaims, error
 	bearerString := r.Header.Get("Authorization")
 	splitToken := strings.Split(bearerString, "Bearer ")
 	if len(splitToken) != 2 {
-		return nil, errors.New(errMalformedHeaderMsg)
+		return nil, errMalformedHeader
 	}
 
 	// Validate token and get claims

--- a/daemon/inertiad/auth/users.go
+++ b/daemon/inertiad/auth/users.go
@@ -108,9 +108,13 @@ func (m *userManager) AddUser(username, password string, admin bool) error {
 
 // RemoveUser removes user with given username and ends related sessions
 func (m *userManager) RemoveUser(username string) error {
+	var u = []byte(username)
 	return m.db.Update(func(tx *bolt.Tx) error {
 		users := tx.Bucket(m.usersBucket)
-		return users.Delete([]byte(username))
+		if users.Get(u) == nil {
+			return errUserNotFound
+		}
+		return users.Delete(u)
 	})
 }
 

--- a/daemon/inertiad/auth/users.go
+++ b/daemon/inertiad/auth/users.go
@@ -9,7 +9,6 @@ import (
 )
 
 var (
-	errSessionNotFound    = errors.New("session not found")
 	errUserNotFound       = errors.New("user not found")
 	errBackupCodeNotFound = errors.New("backup code not found")
 	errMissingCredentials = errors.New("no credentials provided")

--- a/daemon/inertiad/daemon/down.go
+++ b/daemon/inertiad/daemon/down.go
@@ -18,7 +18,7 @@ const (
 // downHandler tries to take the deployment offline
 func (s *Server) downHandler(w http.ResponseWriter, r *http.Request) {
 	if status, _ := s.deployment.GetStatus(s.docker); len(status.Containers) == 0 {
-		render.Render(w, r, res.Err(r, msgNoDeployment, http.StatusPreconditionFailed))
+		render.Render(w, r, res.Err(msgNoDeployment, http.StatusPreconditionFailed))
 		return
 	}
 
@@ -30,12 +30,12 @@ func (s *Server) downHandler(w http.ResponseWriter, r *http.Request) {
 	defer logger.Close()
 
 	if err := s.deployment.Down(s.docker, logger); err == containers.ErrNoContainers {
-		logger.WriteErr(err.Error(), http.StatusPreconditionFailed)
+		logger.Error(res.Err(err.Error(), http.StatusPreconditionFailed))
 		return
 	} else if err != nil {
-		logger.WriteErr(err.Error(), http.StatusInternalServerError)
+		logger.Error(res.ErrInternalServer("failed to shut down project", err))
 		return
 	}
 
-	logger.WriteSuccess("project shut down", http.StatusOK)
+	logger.Success(res.MsgOK("project shut down"))
 }

--- a/daemon/inertiad/daemon/down.go
+++ b/daemon/inertiad/daemon/down.go
@@ -4,8 +4,11 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/go-chi/render"
+
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/containers"
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/log"
+	"github.com/ubclaunchpad/inertia/daemon/inertiad/res"
 )
 
 const (
@@ -15,11 +18,12 @@ const (
 // downHandler tries to take the deployment offline
 func (s *Server) downHandler(w http.ResponseWriter, r *http.Request) {
 	if status, _ := s.deployment.GetStatus(s.docker); len(status.Containers) == 0 {
-		http.Error(w, msgNoDeployment, http.StatusPreconditionFailed)
+		render.Render(w, r, res.Err(r, msgNoDeployment, http.StatusPreconditionFailed))
 		return
 	}
 
 	logger := log.NewLogger(log.LoggerOptions{
+		Request:    r,
 		Stdout:     os.Stdout,
 		HTTPWriter: w,
 	})
@@ -33,5 +37,5 @@ func (s *Server) downHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger.WriteSuccess("Project shut down.", http.StatusOK)
+	logger.WriteSuccess("project shut down", http.StatusOK)
 }

--- a/daemon/inertiad/daemon/down.go
+++ b/daemon/inertiad/daemon/down.go
@@ -22,20 +22,20 @@ func (s *Server) downHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger := log.NewLogger(log.LoggerOptions{
+	var stream = log.NewStreamer(log.StreamerOptions{
 		Request:    r,
 		Stdout:     os.Stdout,
 		HTTPWriter: w,
 	})
-	defer logger.Close()
+	defer s.Close()
 
-	if err := s.deployment.Down(s.docker, logger); err == containers.ErrNoContainers {
-		logger.Error(res.Err(err.Error(), http.StatusPreconditionFailed))
+	if err := s.deployment.Down(s.docker, stream); err == containers.ErrNoContainers {
+		stream.Error(res.Err(err.Error(), http.StatusPreconditionFailed))
 		return
 	} else if err != nil {
-		logger.Error(res.ErrInternalServer("failed to shut down project", err))
+		stream.Error(res.ErrInternalServer("failed to shut down project", err))
 		return
 	}
 
-	logger.Success(res.MsgOK("project shut down"))
+	stream.Success(res.MsgOK("project shut down"))
 }

--- a/daemon/inertiad/daemon/env.go
+++ b/daemon/inertiad/daemon/env.go
@@ -59,8 +59,9 @@ func envPostHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	}
 
 	render.Render(w, r, res.Msg(
-		"environment variable saved - this will be applied the next time your container is started",
-		http.StatusAccepted))
+		"environment variable updated - this will be applied the next time your container is started",
+		http.StatusAccepted,
+		"variable", envReq.Name))
 }
 
 func envGetHandler(s *Server, w http.ResponseWriter, r *http.Request) {

--- a/daemon/inertiad/daemon/env.go
+++ b/daemon/inertiad/daemon/env.go
@@ -31,24 +31,24 @@ func envPostHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	// Parse request
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		logger.WriteErr(err.Error(), http.StatusBadRequest)
+		logger.Error(res.ErrBadRequest(err.Error()))
 		return
 	}
 	defer r.Body.Close()
 	var envReq api.EnvRequest
 	err = json.Unmarshal(body, &envReq)
 	if err != nil {
-		logger.WriteErr(err.Error(), http.StatusBadRequest)
+		logger.Error(res.ErrBadRequest(err.Error()))
 		return
 	}
 	if envReq.Name == "" {
-		logger.WriteErr("no variable name provided", http.StatusBadRequest)
+		logger.Error(res.ErrBadRequest("no variable name provided"))
 		return
 	}
 
 	manager, found := s.deployment.GetDataManager()
 	if !found {
-		logger.WriteErr("no environment manager found", http.StatusPreconditionFailed)
+		logger.Error(res.Err("no environment manager found", http.StatusPreconditionFailed))
 		return
 	}
 
@@ -61,11 +61,11 @@ func envPostHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		)
 	}
 	if err != nil {
-		logger.WriteErr(err.Error(), http.StatusInternalServerError)
+		logger.Error(res.ErrInternalServer("failed to update variable", err))
 		return
 	}
 
-	logger.WriteSuccess("environment variable saved - this will be applied the next time your container is started", http.StatusAccepted)
+	logger.Success(res.Msg("environment variable saved - this will be applied the next time your container is started", http.StatusAccepted))
 }
 
 func envGetHandler(s *Server, w http.ResponseWriter, r *http.Request) {
@@ -78,16 +78,16 @@ func envGetHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 
 	manager, found := s.deployment.GetDataManager()
 	if !found {
-		logger.WriteErr("no environment manager found", http.StatusPreconditionFailed)
+		logger.Error(res.Err("no environment manager found", http.StatusPreconditionFailed))
 		return
 	}
 
 	values, err := manager.GetEnvVariables(false)
 	if err != nil {
-		logger.WriteErr(err.Error(), http.StatusInternalServerError)
+		logger.Error(res.ErrInternalServer("failed to retrieve environment variables", err))
 		return
 	}
 
-	render.Render(w, r, res.Message(r, "configured environment variables retrieved", http.StatusOK,
+	render.Render(w, r, res.Msg("configured environment variables retrieved", http.StatusOK,
 		"variables", values))
 }

--- a/daemon/inertiad/daemon/prune.go
+++ b/daemon/inertiad/daemon/prune.go
@@ -18,6 +18,7 @@ func (s *Server) pruneHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var stream = log.NewStreamer(log.StreamerOptions{
+		Request:    r,
 		Stdout:     os.Stdout,
 		HTTPWriter: w,
 	})

--- a/daemon/inertiad/daemon/prune.go
+++ b/daemon/inertiad/daemon/prune.go
@@ -17,16 +17,16 @@ func (s *Server) pruneHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger := log.NewLogger(log.LoggerOptions{
+	var stream = log.NewStreamer(log.StreamerOptions{
 		Stdout:     os.Stdout,
 		HTTPWriter: w,
 	})
-	defer logger.Close()
+	defer stream.Close()
 
-	if err := s.deployment.Prune(s.docker, logger); err != nil {
-		logger.Error(res.ErrInternalServer("failed to prune Docker assets", err))
+	if err := s.deployment.Prune(s.docker, stream); err != nil {
+		stream.Error(res.ErrInternalServer("failed to prune Docker assets", err))
 		return
 	}
 
-	logger.Success(res.MsgOK("docker assets have been pruned"))
+	stream.Success(res.MsgOK("docker assets have been pruned"))
 }

--- a/daemon/inertiad/daemon/prune.go
+++ b/daemon/inertiad/daemon/prune.go
@@ -4,14 +4,17 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/go-chi/render"
+
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/containers"
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/log"
+	"github.com/ubclaunchpad/inertia/daemon/inertiad/res"
 )
 
 // pruneHandler cleans up Docker assets
 func (s *Server) pruneHandler(w http.ResponseWriter, r *http.Request) {
 	if s.deployment == nil {
-		http.Error(w, msgNoDeployment, http.StatusPreconditionFailed)
+		render.Render(w, r, res.Err(r, msgNoDeployment, http.StatusPreconditionFailed))
 		return
 	}
 

--- a/daemon/inertiad/daemon/reset.go
+++ b/daemon/inertiad/daemon/reset.go
@@ -17,6 +17,7 @@ func (s *Server) resetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var stream = log.NewStreamer(log.StreamerOptions{
+		Request:    r,
 		Stdout:     os.Stdout,
 		HTTPWriter: w,
 	})

--- a/daemon/inertiad/daemon/reset.go
+++ b/daemon/inertiad/daemon/reset.go
@@ -4,13 +4,15 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/go-chi/render"
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/log"
+	"github.com/ubclaunchpad/inertia/daemon/inertiad/res"
 )
 
 // resetHandler shuts down and wipes the project directory
 func (s *Server) resetHandler(w http.ResponseWriter, r *http.Request) {
 	if s.deployment == nil {
-		http.Error(w, msgNoDeployment, http.StatusPreconditionFailed)
+		render.Render(w, r, res.Err(r, msgNoDeployment, http.StatusPreconditionFailed))
 		return
 	}
 

--- a/daemon/inertiad/daemon/reset.go
+++ b/daemon/inertiad/daemon/reset.go
@@ -12,7 +12,7 @@ import (
 // resetHandler shuts down and wipes the project directory
 func (s *Server) resetHandler(w http.ResponseWriter, r *http.Request) {
 	if s.deployment == nil {
-		render.Render(w, r, res.Err(r, msgNoDeployment, http.StatusPreconditionFailed))
+		render.Render(w, r, res.Err(msgNoDeployment, http.StatusPreconditionFailed))
 		return
 	}
 
@@ -24,9 +24,9 @@ func (s *Server) resetHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Goodbye deployment
 	if err := s.deployment.Destroy(s.docker, logger); err != nil {
-		logger.WriteErr(err.Error(), http.StatusInternalServerError)
+		logger.Error(res.ErrInternalServer("failed to remove deployment", err))
 		return
 	}
 
-	logger.WriteSuccess("Project removed from remote.", http.StatusOK)
+	logger.Success(res.MsgOK("project removed"))
 }

--- a/daemon/inertiad/daemon/reset.go
+++ b/daemon/inertiad/daemon/reset.go
@@ -16,17 +16,17 @@ func (s *Server) resetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger := log.NewLogger(log.LoggerOptions{
+	var stream = log.NewStreamer(log.StreamerOptions{
 		Stdout:     os.Stdout,
 		HTTPWriter: w,
 	})
-	defer logger.Close()
+	defer stream.Close()
 
 	// Goodbye deployment
-	if err := s.deployment.Destroy(s.docker, logger); err != nil {
-		logger.Error(res.ErrInternalServer("failed to remove deployment", err))
+	if err := s.deployment.Destroy(s.docker, stream); err != nil {
+		stream.Error(res.ErrInternalServer("failed to remove deployment", err))
 		return
 	}
 
-	logger.Success(res.MsgOK("project removed"))
+	stream.Success(res.MsgOK("project removed"))
 }

--- a/daemon/inertiad/daemon/status.go
+++ b/daemon/inertiad/daemon/status.go
@@ -15,15 +15,15 @@ func (s *Server) statusHandler(w http.ResponseWriter, r *http.Request) {
 	status.InertiaVersion = s.version
 	if status.CommitHash == "" {
 		status.Containers = make([]string, 0)
-		render.Render(w, r, res.Message(r, "status retrieved", http.StatusOK,
+		render.Render(w, r, res.MsgOK("status retrieved",
 			"status", status))
 		return
 	}
 	if err != nil {
-		render.Render(w, r, res.ErrInternalServer(r, "failed to get status", err))
+		render.Render(w, r, res.ErrInternalServer("failed to get status", err))
 		return
 	}
 
-	render.Render(w, r, res.Message(r, "status retrieved", http.StatusOK,
+	render.Render(w, r, res.MsgOK("status retrieved",
 		"status", status))
 }

--- a/daemon/inertiad/daemon/status.go
+++ b/daemon/inertiad/daemon/status.go
@@ -1,42 +1,29 @@
 package daemon
 
 import (
-	"encoding/json"
 	"net/http"
 
-	"github.com/ubclaunchpad/inertia/api"
-	"github.com/ubclaunchpad/inertia/daemon/inertiad/containers"
+	"github.com/go-chi/render"
+
+	"github.com/ubclaunchpad/inertia/daemon/inertiad/res"
 )
 
 // statusHandler returns a formatted string about the status of the
 // deployment and lists currently active project containers
 func (s *Server) statusHandler(w http.ResponseWriter, r *http.Request) {
-	cli, err := containers.NewDockerClient()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	defer cli.Close()
-
-	status, err := s.deployment.GetStatus(cli)
-	if status.CommitHash == "" {
-		status := &api.DeploymentStatus{
-			InertiaVersion: s.version,
-			Containers:     make([]string, 0),
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(status)
-		return
-	}
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
+	status, err := s.deployment.GetStatus(s.docker)
 	status.InertiaVersion = s.version
+	if status.CommitHash == "" {
+		status.Containers = make([]string, 0)
+		render.Render(w, r, res.Message(r, "status retrieved", http.StatusOK,
+			"status", status))
+		return
+	}
+	if err != nil {
+		render.Render(w, r, res.ErrInternalServer(r, "failed to get status", err))
+		return
+	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(status)
+	render.Render(w, r, res.Message(r, "status retrieved", http.StatusOK,
+		"status", status))
 }

--- a/daemon/inertiad/daemon/token.go
+++ b/daemon/inertiad/daemon/token.go
@@ -12,16 +12,16 @@ import (
 func tokenHandler(w http.ResponseWriter, r *http.Request) {
 	keyBytes, err := crypto.GetAPIPrivateKey(nil)
 	if err != nil {
-		render.Render(w, r, res.ErrInternalServer(r, "failed to get signing key", err))
+		render.Render(w, r, res.ErrInternalServer("failed to get signing key", err))
 		return
 	}
 
 	token, err := crypto.GenerateMasterToken(keyBytes.([]byte))
 	if err != nil {
-		render.Render(w, r, res.ErrInternalServer(r, "failed to generate token", err))
+		render.Render(w, r, res.ErrInternalServer("failed to generate token", err))
 		return
 	}
 
-	render.Render(w, r, res.Message(r, "token generated", http.StatusOK,
+	render.Render(w, r, res.MsgOK("token generated",
 		"token", token))
 }

--- a/daemon/inertiad/daemon/token.go
+++ b/daemon/inertiad/daemon/token.go
@@ -3,24 +3,25 @@ package daemon
 import (
 	"net/http"
 
+	"github.com/go-chi/render"
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/crypto"
+	"github.com/ubclaunchpad/inertia/daemon/inertiad/res"
 )
 
 // tokenHandler generates a new token
 func tokenHandler(w http.ResponseWriter, r *http.Request) {
 	keyBytes, err := crypto.GetAPIPrivateKey(nil)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		render.Render(w, r, res.ErrInternalServer(r, "failed to get signing key", err))
 		return
 	}
 
 	token, err := crypto.GenerateMasterToken(keyBytes.([]byte))
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		render.Render(w, r, res.ErrInternalServer(r, "failed to generate token", err))
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/html")
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(token))
+	render.Render(w, r, res.Message(r, "token generated", http.StatusOK,
+		"token", token))
 }

--- a/daemon/inertiad/daemon/token_test.go
+++ b/daemon/inertiad/daemon/token_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/ubclaunchpad/inertia/api"
 )
 
 func TestTokenHandler(t *testing.T) {
@@ -25,8 +26,10 @@ func TestTokenHandler(t *testing.T) {
 	// Record responses
 	recorder := httptest.NewRecorder()
 	handler := http.HandlerFunc(tokenHandler)
-
 	handler.ServeHTTP(recorder, req)
-	assert.Equal(t, generatedTestToken, recorder.Body.String())
+
+	var token string
+	api.Unmarshal(recorder.Body, api.KV{Key: "token", Value: &token})
+	assert.Equal(t, generatedTestToken, token)
 	assert.Equal(t, http.StatusOK, recorder.Code)
 }

--- a/daemon/inertiad/daemon/up.go
+++ b/daemon/inertiad/daemon/up.go
@@ -41,6 +41,7 @@ func (s *Server) upHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Configure streamer
 	var stream = log.NewStreamer(log.StreamerOptions{
+		Request:    r,
 		Stdout:     os.Stdout,
 		HTTPWriter: w,
 		HTTPStream: upReq.Stream,

--- a/daemon/inertiad/daemon/up.go
+++ b/daemon/inertiad/daemon/up.go
@@ -6,23 +6,25 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/go-chi/render"
 	"github.com/ubclaunchpad/inertia/api"
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/crypto"
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/log"
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/project"
+	"github.com/ubclaunchpad/inertia/daemon/inertiad/res"
 )
 
 // upHandler tries to bring the deployment online
 func (s *Server) upHandler(w http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusLengthRequired)
+		render.Render(w, r, res.ErrBadRequest(r, err.Error()))
 		return
 	}
 	defer r.Body.Close()
 	var upReq api.UpRequest
 	if err = json.Unmarshal(body, &upReq); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		render.Render(w, r, res.ErrBadRequest(r, err.Error()))
 		return
 	}
 	var gitOpts = upReq.GitOptions

--- a/daemon/inertiad/daemon/webhook.go
+++ b/daemon/inertiad/daemon/webhook.go
@@ -23,7 +23,7 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		msg := "unable to read payload: " + err.Error()
 		println(msg)
-		render.Render(w, r, res.ErrBadRequest(r, msg))
+		render.Render(w, r, res.ErrBadRequest(msg))
 		return
 	}
 
@@ -37,7 +37,7 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 	if err := webhook.Verify(host, s.state.WebhookSecret, r.Header, body); err != nil {
 		msg := "unable to verify payload: " + err.Error()
 		println(msg)
-		render.Render(w, r, res.ErrBadRequest(r, msg))
+		render.Render(w, r, res.ErrBadRequest(msg))
 		return
 	}
 
@@ -46,7 +46,7 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		msg := "unable to parse payload: " + err.Error()
 		println(msg)
-		render.Render(w, r, res.ErrBadRequest(r, msg))
+		render.Render(w, r, res.ErrBadRequest(msg))
 		return
 	}
 
@@ -63,7 +63,7 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 	//	fmt.Fprint(w, common.MsgDaemonOK)
 	// 	processPullRequestEvent(payload)
 	default:
-		render.Render(w, r, res.ErrBadRequest(r, "unrecognized event type"))
+		render.Render(w, r, res.ErrBadRequest("unrecognized event type"))
 		println("unrecognized event type")
 	}
 }

--- a/daemon/inertiad/daemon/webhook.go
+++ b/daemon/inertiad/daemon/webhook.go
@@ -53,18 +53,19 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 	// process event
 	switch event := payload.GetEventType(); event {
 	case webhook.PingEvent:
-		fmt.Fprint(w, api.MsgDaemonOK)
 		println("ping webhook received")
+		render.Render(w, r, res.Msg(api.MsgDaemonOK, http.StatusAccepted))
 		return
 	case webhook.PushEvent:
-		fmt.Fprint(w, api.MsgDaemonOK)
+		render.Render(w, r, res.Msg(api.MsgDaemonOK, http.StatusAccepted))
 		processPushEvent(s, payload)
 	// case webhook.PullEvent:
 	//	fmt.Fprint(w, common.MsgDaemonOK)
 	// 	processPullRequestEvent(payload)
 	default:
-		render.Render(w, r, res.ErrBadRequest("unrecognized event type"))
 		println("unrecognized event type")
+		render.Render(w, r, res.ErrBadRequest("unrecognized event type",
+			"type", event))
 	}
 }
 

--- a/daemon/inertiad/daemon/webhook.go
+++ b/daemon/inertiad/daemon/webhook.go
@@ -2,14 +2,15 @@ package daemon
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 
+	"github.com/go-chi/render"
 	"github.com/ubclaunchpad/inertia/api"
 	"github.com/ubclaunchpad/inertia/common"
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/project"
+	"github.com/ubclaunchpad/inertia/daemon/inertiad/res"
 	"github.com/ubclaunchpad/inertia/daemon/inertiad/webhook"
 )
 
@@ -21,8 +22,8 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		msg := "unable to read payload: " + err.Error()
-		http.Error(w, msg, http.StatusBadRequest)
 		println(msg)
+		render.Render(w, r, res.ErrBadRequest(r, msg))
 		return
 	}
 
@@ -35,8 +36,8 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := webhook.Verify(host, s.state.WebhookSecret, r.Header, body); err != nil {
 		msg := "unable to verify payload: " + err.Error()
-		http.Error(w, msg, http.StatusBadRequest)
 		println(msg)
+		render.Render(w, r, res.ErrBadRequest(r, msg))
 		return
 	}
 
@@ -44,8 +45,8 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 	payload, err := webhook.Parse(host, event, r.Header, body)
 	if err != nil {
 		msg := "unable to parse payload: " + err.Error()
-		http.Error(w, msg, http.StatusBadRequest)
 		println(msg)
+		render.Render(w, r, res.ErrBadRequest(r, msg))
 		return
 	}
 
@@ -57,12 +58,12 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	case webhook.PushEvent:
 		fmt.Fprint(w, api.MsgDaemonOK)
-		processPushEvent(s, payload, os.Stdout)
+		processPushEvent(s, payload)
 	// case webhook.PullEvent:
 	//	fmt.Fprint(w, common.MsgDaemonOK)
 	// 	processPullRequestEvent(payload)
 	default:
-		http.Error(w, "unrecognized event type", http.StatusBadRequest)
+		render.Render(w, r, res.ErrBadRequest(r, "unrecognized event type"))
 		println("unrecognized event type")
 	}
 }
@@ -79,41 +80,41 @@ func dockerWebhookHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // processPushEvent prints information about the given PushEvent.
-func processPushEvent(s *Server, p webhook.Payload, out io.Writer) {
-	fmt.Fprintf(out, "Received %s push event: %s (%s)\n",
+func processPushEvent(s *Server, p webhook.Payload) {
+	fmt.Printf("Received %s push event: %s (%s)\n",
 		p.GetSource(), p.GetRepoName(), p.GetRef())
 
 	// Ignore event if repository not set up yet, otherwise
 	// let deploy() handle the update.
 	if status, _ := s.deployment.GetStatus(s.docker); status.CommitHash == "" {
-		fmt.Fprintln(out, msgNoDeployment)
+		fmt.Println(msgNoDeployment)
 		return
 	}
 
 	// Check for matching remotes
 	if err := s.deployment.CompareRemotes(p.GetSSHURL()); err != nil {
-		fmt.Fprintln(out, err.Error())
+		fmt.Println(err.Error())
 		return
 	}
 
 	// Check for matching branch
 	var branch = common.GetBranchFromRef(p.GetRef())
 	if s.deployment.GetBranch() != branch {
-		fmt.Fprintf(out, "Ignoring event: event branch %s does not match deployed branch %s\n",
+		fmt.Printf("Ignoring event: event branch %s does not match deployed branch %s\n",
 			branch, s.deployment.GetBranch())
 		return
 	}
 
 	// If branches match, deploy
-	fmt.Fprintf(out, "Accepting event: event branch %s matches deployed branch %s\n",
+	fmt.Printf("Accepting event: event branch %s matches deployed branch %s\n",
 		branch, s.deployment.GetBranch())
 	deploy, err := s.deployment.Deploy(s.docker, os.Stdout, project.DeployOptions{})
 	if err != nil {
-		fmt.Fprintln(out, "Build failed: "+err.Error())
+		fmt.Println("Build failed: " + err.Error())
 		return
 	}
 
 	if err = deploy(); err != nil {
-		fmt.Fprintln(out, "Deploy failed: "+err.Error())
+		fmt.Println("Deploy failed: " + err.Error())
 	}
 }

--- a/daemon/inertiad/log/logger.go
+++ b/daemon/inertiad/log/logger.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/go-chi/render"
 	"github.com/gorilla/websocket"
@@ -71,23 +70,23 @@ func (l *DaemonLogger) Println(a interface{}) {
 	fmt.Fprintln(l.Writer, a)
 }
 
-// WriteErr directs message and status to http.Error when appropriate
-func (l *DaemonLogger) WriteErr(msg string, status int) {
-	fmt.Fprintf(l.Writer, "[ERROR %s] %s\n", strconv.Itoa(status), msg)
+// Error directs message and status to http.Error when appropriate
+func (l *DaemonLogger) Error(res *res.ErrResponse) {
+	fmt.Fprintf(l.Writer, "[ERROR %d] %s\n", res.HTTPStatusCode, res.Message)
 	if l.socket == nil {
-		render.Render(l.httpWriter, l.req, res.Err(l.req, msg, status))
+		render.Render(l.httpWriter, l.req, res)
 	} else {
-		l.Close(CloseOpts{msg, status})
+		l.Close(CloseOpts{res.Message, res.HTTPStatusCode})
 	}
 }
 
-// WriteSuccess directs status to Header and sets content type when appropriate
-func (l *DaemonLogger) WriteSuccess(msg string, status int) {
-	fmt.Fprintf(l.Writer, "[SUCCESS %s] %s\n", strconv.Itoa(status), msg)
+// Success directs status to Header and sets content type when appropriate
+func (l *DaemonLogger) Success(res *res.MsgResponse) {
+	fmt.Fprintf(l.Writer, "[SUCCESS %d] %s\n", res.HTTPStatusCode, res.Message)
 	if l.socket == nil && !l.httpStream {
-		render.Render(l.httpWriter, l.req, res.Message(l.req, msg, status))
+		render.Render(l.httpWriter, l.req, res)
 	} else {
-		l.Close(CloseOpts{msg, status})
+		l.Close(CloseOpts{res.Message, res.HTTPStatusCode})
 	}
 }
 

--- a/daemon/inertiad/log/logger.go
+++ b/daemon/inertiad/log/logger.go
@@ -72,7 +72,7 @@ func (l *DaemonLogger) Println(a interface{}) {
 
 // Error directs message and status to http.Error when appropriate
 func (l *DaemonLogger) Error(res *res.ErrResponse) {
-	fmt.Fprintf(l.Writer, "[ERROR %d] %s\n", res.HTTPStatusCode, res.Message)
+	fmt.Fprint(l.Writer, res.Error().Error())
 	if l.socket == nil {
 		render.Render(l.httpWriter, l.req, res)
 	} else {

--- a/daemon/inertiad/log/logger.go
+++ b/daemon/inertiad/log/logger.go
@@ -72,7 +72,7 @@ func (l *DaemonLogger) Println(a interface{}) {
 
 // Error directs message and status to http.Error when appropriate
 func (l *DaemonLogger) Error(res *res.ErrResponse) {
-	fmt.Fprint(l.Writer, res.Error().Error())
+	fmt.Fprintln(l.Writer, res.Error().Error())
 	if l.socket == nil {
 		render.Render(l.httpWriter, l.req, res)
 	} else {
@@ -82,7 +82,7 @@ func (l *DaemonLogger) Error(res *res.ErrResponse) {
 
 // Success directs status to Header and sets content type when appropriate
 func (l *DaemonLogger) Success(res *res.MsgResponse) {
-	fmt.Fprintf(l.Writer, "[SUCCESS %d] %s\n", res.HTTPStatusCode, res.Message)
+	fmt.Fprintf(l.Writer, "[success %d] %s\n", res.HTTPStatusCode, res.Message)
 	if l.socket == nil && !l.httpStream {
 		render.Render(l.httpWriter, l.req, res)
 	} else {

--- a/daemon/inertiad/log/logger_test.go
+++ b/daemon/inertiad/log/logger_test.go
@@ -88,12 +88,12 @@ func TestSuccess(t *testing.T) {
 		Writer:     &b,
 		socket:     &mockSocketWriter{},
 	}
-	logger.Success(res.Message("Wee!", 200))
+	logger.Success(res.MsgOK("Wee!"))
 	assert.Equal(t, "[SUCCESS 200] Wee!\n", b.String())
 
 	// Test direct to httpResponse
 	logger.socket = nil
-	logger.Success(res.Message("Wee!", 200))
+	logger.Success(res.MsgOK("Wee!"))
 	body, err := api.Unmarshal(w.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "Wee!", body.Message)

--- a/daemon/inertiad/log/logger_test.go
+++ b/daemon/inertiad/log/logger_test.go
@@ -65,7 +65,7 @@ func TestErr(t *testing.T) {
 		socket:     &mockSocketWriter{},
 	}
 	logger.Error(res.ErrBadRequest("Wee!"))
-	assert.Equal(t, "[ERROR 400] Wee!\n", b.String())
+	assert.Equal(t, "[error 400] Wee!\n", b.String())
 
 	// Test direct to httpResponse
 	logger.socket = nil
@@ -89,7 +89,7 @@ func TestSuccess(t *testing.T) {
 		socket:     &mockSocketWriter{},
 	}
 	logger.Success(res.MsgOK("Wee!"))
-	assert.Equal(t, "[SUCCESS 200] Wee!\n", b.String())
+	assert.Equal(t, "[success 200] Wee!\n", b.String())
 
 	// Test direct to httpResponse
 	logger.socket = nil

--- a/daemon/inertiad/log/streamer.go
+++ b/daemon/inertiad/log/streamer.go
@@ -51,6 +51,7 @@ func NewStreamer(opts StreamerOptions) *Streamer {
 	}
 
 	return &Streamer{
+		req:        opts.Request,
 		httpWriter: opts.HTTPWriter,
 		httpStream: opts.HTTPStream,
 		socket:     opts.Socket,

--- a/daemon/inertiad/log/streamer_test.go
+++ b/daemon/inertiad/log/streamer_test.go
@@ -24,14 +24,14 @@ func (m *mockSocketWriter) WriteMessage(t int, bytes []byte) error {
 }
 func (m *mockSocketWriter) getWrittenBytes() *bytes.Buffer { return &m.Buffer }
 
-func TestNewLogger(t *testing.T) {
-	logger := NewLogger(LoggerOptions{})
+func TestNewStreamer(t *testing.T) {
+	logger := NewStreamer(StreamerOptions{})
 	assert.NotNil(t, logger)
 }
 
 func TestWrite(t *testing.T) {
 	var b bytes.Buffer
-	writer := NewLogger(LoggerOptions{Stdout: &b})
+	writer := NewStreamer(StreamerOptions{Stdout: &b})
 	writer.Write([]byte("whoah!"))
 	assert.Equal(t, "whoah!", b.String())
 }
@@ -39,7 +39,7 @@ func TestWrite(t *testing.T) {
 func TestWriteMulti(t *testing.T) {
 	var b1 bytes.Buffer
 	socketWriter := &mockSocketWriter{}
-	writer := NewLogger(LoggerOptions{Stdout: &b1, Socket: socketWriter})
+	writer := NewStreamer(StreamerOptions{Stdout: &b1, Socket: socketWriter})
 	writer.Write([]byte("whoah!"))
 	assert.Equal(t, "whoah!", b1.String())
 	assert.Equal(t, "whoah!", socketWriter.getWrittenBytes().String())
@@ -47,7 +47,7 @@ func TestWriteMulti(t *testing.T) {
 
 func TestPrintln(t *testing.T) {
 	var b bytes.Buffer
-	logger := &DaemonLogger{Writer: &b}
+	logger := &Streamer{Writer: &b}
 	logger.Println("what???")
 	assert.Equal(t, "what???\n", b.String())
 }
@@ -58,7 +58,7 @@ func TestErr(t *testing.T) {
 
 	// Test streaming
 	var req = httptest.NewRequest("GET", "/asdf", nil)
-	logger := &DaemonLogger{
+	logger := &Streamer{
 		req:        req,
 		Writer:     &b,
 		httpWriter: w,
@@ -82,7 +82,7 @@ func TestSuccess(t *testing.T) {
 
 	// Test streaming
 	var req = httptest.NewRequest("GET", "/asdf", nil)
-	logger := &DaemonLogger{
+	logger := &Streamer{
 		req:        req,
 		httpWriter: w,
 		Writer:     &b,

--- a/daemon/inertiad/res/base.go
+++ b/daemon/inertiad/res/base.go
@@ -1,0 +1,22 @@
+package res
+
+import "net/http"
+
+// BaseResponse is the underlying response structure to all responses
+type BaseResponse struct {
+	HTTPStatusCode int                    `json:"-"`
+	Message        string                 `json:"message"`
+	RequestID      string                 `json:"request-id"`
+	Body           map[string]interface{} `json:"body,omitempty"`
+}
+
+func newBaseRequest(r *http.Request, message string, code int, kvs []interface{}) BaseResponse {
+	var body = make(map[string]interface{})
+	for i := 0; i < len(kvs); i += 2 {
+		body[kvs[i].(string)] = kvs[i+1]
+	}
+	return BaseResponse{
+		HTTPStatusCode: code,
+		Message:        message,
+	}
+}

--- a/daemon/inertiad/res/base.go
+++ b/daemon/inertiad/res/base.go
@@ -1,22 +1,27 @@
 package res
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/middleware"
+)
 
 // BaseResponse is the underlying response structure to all responses
 type BaseResponse struct {
 	HTTPStatusCode int                    `json:"-"`
 	Message        string                 `json:"message"`
-	RequestID      string                 `json:"request-id"`
+	RequestID      string                 `json:"request_id"`
 	Body           map[string]interface{} `json:"body,omitempty"`
 }
 
 func newBaseRequest(r *http.Request, message string, code int, kvs []interface{}) BaseResponse {
 	var body = make(map[string]interface{})
-	for i := 0; i < len(kvs); i += 2 {
+	for i := 0; i < len(kvs)-1; i += 2 {
 		body[kvs[i].(string)] = kvs[i+1]
 	}
 	return BaseResponse{
 		HTTPStatusCode: code,
 		Message:        message,
+		RequestID:      middleware.GetReqID(r.Context()),
 	}
 }

--- a/daemon/inertiad/res/base.go
+++ b/daemon/inertiad/res/base.go
@@ -37,13 +37,12 @@ func (b *BaseResponse) Render(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func formatData(kvs []interface{}) (e string, data map[string]interface{}) {
+func formatData(kvs []interface{}) (e string, d interface{}) {
 	if len(kvs) < 1 {
 		return "", nil
 	}
 
-	data = make(map[string]interface{})
-	var hasNonErrorData = false
+	var data = make(map[string]interface{})
 	for i := 0; i < len(kvs)-1; i += 2 {
 		var (
 			k = kvs[i].(string)
@@ -57,12 +56,16 @@ func formatData(kvs []interface{}) (e string, data map[string]interface{}) {
 				e = err
 			}
 		} else {
-			hasNonErrorData = true
 			data[k] = v
 		}
 	}
 
-	if !hasNonErrorData {
+	// We need to make sure we *explicitly* return a nil-value interface, since
+	// if we assign a map, even if it is null, an empty interface will now assume
+	// a type value, making it non-nil, which means the `omitempty` directive will
+	// no longer trigger.
+	// See https://golang.org/doc/faq#nil_error
+	if len(data) < 1 {
 		return e, nil
 	}
 	return e, data

--- a/daemon/inertiad/res/base.go
+++ b/daemon/inertiad/res/base.go
@@ -19,24 +19,7 @@ func newBaseResponse(
 	code int,
 	kvs []interface{},
 ) *BaseResponse {
-	var data = make(map[string]interface{})
-	var e string
-	for i := 0; i < len(kvs)-1; i += 2 {
-		var (
-			k = kvs[i].(string)
-			v = kvs[i+1]
-		)
-		if k == "error" {
-			switch err := v.(type) {
-			case error:
-				e = err.Error()
-			case string:
-				e = err
-			}
-		} else {
-			data[k] = v
-		}
-	}
+	e, data := formatData(kvs)
 	return &BaseResponse{
 		api.BaseResponse{
 			HTTPStatusCode: code,
@@ -54,8 +37,39 @@ func (b *BaseResponse) Render(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
+func formatData(kvs []interface{}) (e string, data map[string]interface{}) {
+	if len(kvs) < 1 {
+		return "", nil
+	}
+
+	data = make(map[string]interface{})
+	var hasNonErrorData = false
+	for i := 0; i < len(kvs)-1; i += 2 {
+		var (
+			k = kvs[i].(string)
+			v = kvs[i+1]
+		)
+		if k == "error" {
+			switch err := v.(type) {
+			case error:
+				e = err.Error()
+			case string:
+				e = err
+			}
+		} else {
+			hasNonErrorData = true
+			data[k] = v
+		}
+	}
+
+	if !hasNonErrorData {
+		return e, nil
+	}
+	return e, data
+}
+
 func reqID(r *http.Request) string {
-	if r == nil {
+	if r == nil || r.Context() == nil {
 		return ""
 	}
 	return middleware.GetReqID(r.Context())

--- a/daemon/inertiad/res/base.go
+++ b/daemon/inertiad/res/base.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ubclaunchpad/inertia/api"
 )
 
-func newBaseRequest(r *http.Request, message string, code int, kvs []interface{}) api.BaseResponse {
+func newBaseResponse(r *http.Request, message string, code int, kvs []interface{}) api.BaseResponse {
 	var data = make(map[string]interface{})
 	var e string
 	for i := 0; i < len(kvs)-1; i += 2 {

--- a/daemon/inertiad/res/base.go
+++ b/daemon/inertiad/res/base.go
@@ -9,21 +9,16 @@ import (
 	"github.com/ubclaunchpad/inertia/api"
 )
 
-type baseResponse struct {
+// BaseResponse is a container class around api.BaseResponse
+type BaseResponse struct {
 	api.BaseResponse
-}
-
-func (b *baseResponse) Render(w http.ResponseWriter, r *http.Request) error {
-	b.RequestID = reqID(r)
-	render.Status(r, b.HTTPStatusCode)
-	return nil
 }
 
 func newBaseResponse(
 	message string,
 	code int,
 	kvs []interface{},
-) *baseResponse {
+) *BaseResponse {
 	var data = make(map[string]interface{})
 	var e string
 	for i := 0; i < len(kvs)-1; i += 2 {
@@ -42,7 +37,7 @@ func newBaseResponse(
 			data[k] = v
 		}
 	}
-	return &baseResponse{
+	return &BaseResponse{
 		api.BaseResponse{
 			HTTPStatusCode: code,
 			Message:        message,
@@ -50,6 +45,13 @@ func newBaseResponse(
 			Data:           data,
 		},
 	}
+}
+
+// Render implements chi's render.Renderer
+func (b *BaseResponse) Render(w http.ResponseWriter, r *http.Request) error {
+	b.RequestID = reqID(r)
+	render.Status(r, b.HTTPStatusCode)
+	return nil
 }
 
 func reqID(r *http.Request) string {

--- a/daemon/inertiad/res/base.go
+++ b/daemon/inertiad/res/base.go
@@ -8,7 +8,12 @@ import (
 	"github.com/ubclaunchpad/inertia/api"
 )
 
-func newBaseResponse(r *http.Request, message string, code int, kvs []interface{}) api.BaseResponse {
+func newBaseResponse(
+	r *http.Request,
+	message string,
+	code int,
+	kvs []interface{},
+) api.BaseResponse {
 	var data = make(map[string]interface{})
 	var e string
 	for i := 0; i < len(kvs)-1; i += 2 {
@@ -31,7 +36,7 @@ func newBaseResponse(r *http.Request, message string, code int, kvs []interface{
 		HTTPStatusCode: code,
 		Message:        message,
 		RequestID:      middleware.GetReqID(r.Context()),
-		Error:          e,
+		Err:            e,
 		Data:           data,
 	}
 }

--- a/daemon/inertiad/res/doc.go
+++ b/daemon/inertiad/res/doc.go
@@ -1,0 +1,2 @@
+// Package res provides simple HTTP response primitives
+package res

--- a/daemon/inertiad/res/error.go
+++ b/daemon/inertiad/res/error.go
@@ -1,0 +1,46 @@
+package res
+
+import (
+	"net/http"
+
+	"github.com/go-chi/render"
+)
+
+// ErrResponse is the template for a typical HTTP response for errors
+type ErrResponse struct {
+	BaseResponse
+}
+
+// Render renders an ErrResponse
+func (e *ErrResponse) Render(w http.ResponseWriter, r *http.Request) error {
+	render.Status(r, e.HTTPStatusCode)
+	return nil
+}
+
+// Err is a basic error response constructor
+func Err(r *http.Request, message string, code int, kvs ...interface{}) render.Renderer {
+	return &ErrResponse{
+		BaseResponse: newBaseRequest(r, message, code, kvs),
+	}
+}
+
+// ErrInternalServer is a shortcut for internal server errors
+func ErrInternalServer(r *http.Request, message string, kvs ...interface{}) render.Renderer {
+	return &ErrResponse{
+		BaseResponse: newBaseRequest(r, message, http.StatusInternalServerError, kvs),
+	}
+}
+
+// ErrBadRequest is a shortcut for bad requests
+func ErrBadRequest(r *http.Request, message string, kvs ...interface{}) render.Renderer {
+	return &ErrResponse{
+		BaseResponse: newBaseRequest(r, message, http.StatusBadRequest, kvs),
+	}
+}
+
+// ErrUnauthorized is a shortcut for unauthorized requests
+func ErrUnauthorized(r *http.Request, message string, kvs ...interface{}) render.Renderer {
+	return &ErrResponse{
+		BaseResponse: newBaseRequest(r, message, http.StatusUnauthorized, kvs),
+	}
+}

--- a/daemon/inertiad/res/error.go
+++ b/daemon/inertiad/res/error.go
@@ -39,5 +39,5 @@ func ErrForbidden(message string, kvs ...interface{}) *ErrResponse {
 
 // ErrNotFound is a shortcut for forbidden requests
 func ErrNotFound(message string, kvs ...interface{}) *ErrResponse {
-	return &ErrResponse{newBaseResponse(message, http.StatusForbidden, kvs)}
+	return &ErrResponse{newBaseResponse(message, http.StatusNotFound, kvs)}
 }

--- a/daemon/inertiad/res/error.go
+++ b/daemon/inertiad/res/error.go
@@ -6,7 +6,7 @@ import (
 
 // ErrResponse is the template for a typical HTTP response for errors
 type ErrResponse struct {
-	*baseResponse
+	*BaseResponse
 }
 
 // Err is a basic error response constructor

--- a/daemon/inertiad/res/error.go
+++ b/daemon/inertiad/res/error.go
@@ -22,7 +22,7 @@ func (e *ErrResponse) Render(w http.ResponseWriter, r *http.Request) error {
 // Err is a basic error response constructor
 func Err(r *http.Request, message string, code int, kvs ...interface{}) render.Renderer {
 	return &ErrResponse{
-		BaseResponse: newBaseRequest(r, message, code, kvs),
+		BaseResponse: newBaseResponse(r, message, code, kvs),
 	}
 }
 
@@ -35,34 +35,34 @@ func ErrInternalServer(r *http.Request, message string, err error, kvs ...interf
 		kvs = append(kvs, "error", err.Error())
 	}
 	return &ErrResponse{
-		BaseResponse: newBaseRequest(r, message, http.StatusInternalServerError, kvs),
+		BaseResponse: newBaseResponse(r, message, http.StatusInternalServerError, kvs),
 	}
 }
 
 // ErrBadRequest is a shortcut for bad requests
 func ErrBadRequest(r *http.Request, message string, kvs ...interface{}) render.Renderer {
 	return &ErrResponse{
-		BaseResponse: newBaseRequest(r, message, http.StatusBadRequest, kvs),
+		BaseResponse: newBaseResponse(r, message, http.StatusBadRequest, kvs),
 	}
 }
 
 // ErrUnauthorized is a shortcut for unauthorized requests
 func ErrUnauthorized(r *http.Request, message string, kvs ...interface{}) render.Renderer {
 	return &ErrResponse{
-		BaseResponse: newBaseRequest(r, message, http.StatusUnauthorized, kvs),
+		BaseResponse: newBaseResponse(r, message, http.StatusUnauthorized, kvs),
 	}
 }
 
 // ErrForbidden is a shortcut for forbidden requests
 func ErrForbidden(r *http.Request, message string, kvs ...interface{}) render.Renderer {
 	return &ErrResponse{
-		BaseResponse: newBaseRequest(r, message, http.StatusForbidden, kvs),
+		BaseResponse: newBaseResponse(r, message, http.StatusForbidden, kvs),
 	}
 }
 
 // ErrNotFound is a shortcut for forbidden requests
 func ErrNotFound(r *http.Request, message string, kvs ...interface{}) render.Renderer {
 	return &ErrResponse{
-		BaseResponse: newBaseRequest(r, message, http.StatusForbidden, kvs),
+		BaseResponse: newBaseResponse(r, message, http.StatusForbidden, kvs),
 	}
 }

--- a/daemon/inertiad/res/error.go
+++ b/daemon/inertiad/res/error.go
@@ -24,8 +24,10 @@ func Err(r *http.Request, message string, code int, kvs ...interface{}) render.R
 	}
 }
 
-// ErrInternalServer is a shortcut for internal server errors
-func ErrInternalServer(r *http.Request, message string, kvs ...interface{}) render.Renderer {
+// ErrInternalServer is a shortcut for internal server errors. It should be
+// accompanied by an actual error.
+func ErrInternalServer(r *http.Request, message string, err error, kvs ...interface{}) render.Renderer {
+	kvs = append(kvs, "error", err.Error())
 	return &ErrResponse{
 		BaseResponse: newBaseRequest(r, message, http.StatusInternalServerError, kvs),
 	}
@@ -42,5 +44,19 @@ func ErrBadRequest(r *http.Request, message string, kvs ...interface{}) render.R
 func ErrUnauthorized(r *http.Request, message string, kvs ...interface{}) render.Renderer {
 	return &ErrResponse{
 		BaseResponse: newBaseRequest(r, message, http.StatusUnauthorized, kvs),
+	}
+}
+
+// ErrForbidden is a shortcut for forbidden requests
+func ErrForbidden(r *http.Request, message string, kvs ...interface{}) render.Renderer {
+	return &ErrResponse{
+		BaseResponse: newBaseRequest(r, message, http.StatusForbidden, kvs),
+	}
+}
+
+// ErrNotFound is a shortcut for forbidden requests
+func ErrNotFound(r *http.Request, message string, kvs ...interface{}) render.Renderer {
+	return &ErrResponse{
+		BaseResponse: newBaseRequest(r, message, http.StatusForbidden, kvs),
 	}
 }

--- a/daemon/inertiad/res/error.go
+++ b/daemon/inertiad/res/error.go
@@ -4,11 +4,13 @@ import (
 	"net/http"
 
 	"github.com/go-chi/render"
+
+	"github.com/ubclaunchpad/inertia/api"
 )
 
 // ErrResponse is the template for a typical HTTP response for errors
 type ErrResponse struct {
-	BaseResponse
+	api.BaseResponse
 }
 
 // Render renders an ErrResponse
@@ -27,7 +29,11 @@ func Err(r *http.Request, message string, code int, kvs ...interface{}) render.R
 // ErrInternalServer is a shortcut for internal server errors. It should be
 // accompanied by an actual error.
 func ErrInternalServer(r *http.Request, message string, err error, kvs ...interface{}) render.Renderer {
-	kvs = append(kvs, "error", err.Error())
+	if len(kvs) == 0 {
+		kvs = []interface{}{"error", err.Error()}
+	} else {
+		kvs = append(kvs, "error", err.Error())
+	}
 	return &ErrResponse{
 		BaseResponse: newBaseRequest(r, message, http.StatusInternalServerError, kvs),
 	}

--- a/daemon/inertiad/res/error.go
+++ b/daemon/inertiad/res/error.go
@@ -16,7 +16,7 @@ func Err(message string, code int, kvs ...interface{}) *ErrResponse {
 
 // ErrInternalServer is a shortcut for internal server errors. It should be
 // accompanied by an actual error.
-func ErrInternalServer(r *http.Request, message string, err error, kvs ...interface{}) *ErrResponse {
+func ErrInternalServer(message string, err error, kvs ...interface{}) *ErrResponse {
 	var b = newBaseResponse(message, http.StatusInternalServerError, kvs)
 	b.Err = err.Error()
 	return &ErrResponse{b}

--- a/daemon/inertiad/res/error.go
+++ b/daemon/inertiad/res/error.go
@@ -2,67 +2,42 @@ package res
 
 import (
 	"net/http"
-
-	"github.com/go-chi/render"
-
-	"github.com/ubclaunchpad/inertia/api"
 )
 
 // ErrResponse is the template for a typical HTTP response for errors
 type ErrResponse struct {
-	api.BaseResponse
-}
-
-// Render renders an ErrResponse
-func (e *ErrResponse) Render(w http.ResponseWriter, r *http.Request) error {
-	render.Status(r, e.HTTPStatusCode)
-	return nil
+	*baseResponse
 }
 
 // Err is a basic error response constructor
-func Err(r *http.Request, message string, code int, kvs ...interface{}) render.Renderer {
-	return &ErrResponse{
-		BaseResponse: newBaseResponse(r, message, code, kvs),
-	}
+func Err(message string, code int, kvs ...interface{}) *ErrResponse {
+	return &ErrResponse{newBaseResponse(message, code, kvs)}
 }
 
 // ErrInternalServer is a shortcut for internal server errors. It should be
 // accompanied by an actual error.
-func ErrInternalServer(r *http.Request, message string, err error, kvs ...interface{}) render.Renderer {
-	if len(kvs) == 0 {
-		kvs = []interface{}{"error", err.Error()}
-	} else {
-		kvs = append(kvs, "error", err.Error())
-	}
-	return &ErrResponse{
-		BaseResponse: newBaseResponse(r, message, http.StatusInternalServerError, kvs),
-	}
+func ErrInternalServer(r *http.Request, message string, err error, kvs ...interface{}) *ErrResponse {
+	var b = newBaseResponse(message, http.StatusInternalServerError, kvs)
+	b.Err = err.Error()
+	return &ErrResponse{b}
 }
 
 // ErrBadRequest is a shortcut for bad requests
-func ErrBadRequest(r *http.Request, message string, kvs ...interface{}) render.Renderer {
-	return &ErrResponse{
-		BaseResponse: newBaseResponse(r, message, http.StatusBadRequest, kvs),
-	}
+func ErrBadRequest(message string, kvs ...interface{}) *ErrResponse {
+	return &ErrResponse{newBaseResponse(message, http.StatusBadRequest, kvs)}
 }
 
 // ErrUnauthorized is a shortcut for unauthorized requests
-func ErrUnauthorized(r *http.Request, message string, kvs ...interface{}) render.Renderer {
-	return &ErrResponse{
-		BaseResponse: newBaseResponse(r, message, http.StatusUnauthorized, kvs),
-	}
+func ErrUnauthorized(message string, kvs ...interface{}) *ErrResponse {
+	return &ErrResponse{newBaseResponse(message, http.StatusUnauthorized, kvs)}
 }
 
 // ErrForbidden is a shortcut for forbidden requests
-func ErrForbidden(r *http.Request, message string, kvs ...interface{}) render.Renderer {
-	return &ErrResponse{
-		BaseResponse: newBaseResponse(r, message, http.StatusForbidden, kvs),
-	}
+func ErrForbidden(message string, kvs ...interface{}) *ErrResponse {
+	return &ErrResponse{newBaseResponse(message, http.StatusForbidden, kvs)}
 }
 
 // ErrNotFound is a shortcut for forbidden requests
-func ErrNotFound(r *http.Request, message string, kvs ...interface{}) render.Renderer {
-	return &ErrResponse{
-		BaseResponse: newBaseResponse(r, message, http.StatusForbidden, kvs),
-	}
+func ErrNotFound(message string, kvs ...interface{}) *ErrResponse {
+	return &ErrResponse{newBaseResponse(message, http.StatusForbidden, kvs)}
 }

--- a/daemon/inertiad/res/message.go
+++ b/daemon/inertiad/res/message.go
@@ -1,0 +1,25 @@
+package res
+
+import (
+	"net/http"
+
+	"github.com/go-chi/render"
+)
+
+// MsgResponse is the template for a typical HTTP response for messages
+type MsgResponse struct {
+	BaseResponse
+}
+
+// Render renders a MsgResponse
+func (m *MsgResponse) Render(w http.ResponseWriter, r *http.Request) error {
+	render.Status(r, m.HTTPStatusCode)
+	return nil
+}
+
+// Message is a shortcut for non-error statuses
+func Message(r *http.Request, message string, code int, kvs ...interface{}) render.Renderer {
+	return &MsgResponse{
+		BaseResponse: newBaseRequest(r, message, code, kvs),
+	}
+}

--- a/daemon/inertiad/res/message.go
+++ b/daemon/inertiad/res/message.go
@@ -4,7 +4,7 @@ import "net/http"
 
 // MsgResponse is the template for a typical HTTP response for messages
 type MsgResponse struct {
-	*baseResponse
+	*BaseResponse
 }
 
 // Msg is a shortcut for non-error statuses

--- a/daemon/inertiad/res/message.go
+++ b/daemon/inertiad/res/message.go
@@ -1,27 +1,11 @@
 package res
 
-import (
-	"net/http"
-
-	"github.com/go-chi/render"
-
-	"github.com/ubclaunchpad/inertia/api"
-)
-
 // MsgResponse is the template for a typical HTTP response for messages
 type MsgResponse struct {
-	api.BaseResponse
-}
-
-// Render renders a MsgResponse
-func (m *MsgResponse) Render(w http.ResponseWriter, r *http.Request) error {
-	render.Status(r, m.HTTPStatusCode)
-	return nil
+	*baseResponse
 }
 
 // Message is a shortcut for non-error statuses
-func Message(r *http.Request, message string, code int, kvs ...interface{}) render.Renderer {
-	return &MsgResponse{
-		BaseResponse: newBaseResponse(r, message, code, kvs),
-	}
+func Message(message string, code int, kvs ...interface{}) *MsgResponse {
+	return &MsgResponse{newBaseResponse(message, code, kvs)}
 }

--- a/daemon/inertiad/res/message.go
+++ b/daemon/inertiad/res/message.go
@@ -1,11 +1,18 @@
 package res
 
+import "net/http"
+
 // MsgResponse is the template for a typical HTTP response for messages
 type MsgResponse struct {
 	*baseResponse
 }
 
-// Message is a shortcut for non-error statuses
-func Message(message string, code int, kvs ...interface{}) *MsgResponse {
+// Msg is a shortcut for non-error statuses
+func Msg(message string, code int, kvs ...interface{}) *MsgResponse {
 	return &MsgResponse{newBaseResponse(message, code, kvs)}
+}
+
+// MsgOK is a shortcut for an ok-status response
+func MsgOK(message string, kvs ...interface{}) *MsgResponse {
+	return &MsgResponse{newBaseResponse(message, http.StatusOK, kvs)}
 }

--- a/daemon/inertiad/res/message.go
+++ b/daemon/inertiad/res/message.go
@@ -4,11 +4,13 @@ import (
 	"net/http"
 
 	"github.com/go-chi/render"
+
+	"github.com/ubclaunchpad/inertia/api"
 )
 
 // MsgResponse is the template for a typical HTTP response for messages
 type MsgResponse struct {
-	BaseResponse
+	api.BaseResponse
 }
 
 // Render renders a MsgResponse

--- a/daemon/inertiad/res/message.go
+++ b/daemon/inertiad/res/message.go
@@ -22,6 +22,6 @@ func (m *MsgResponse) Render(w http.ResponseWriter, r *http.Request) error {
 // Message is a shortcut for non-error statuses
 func Message(r *http.Request, message string, code int, kvs ...interface{}) render.Renderer {
 	return &MsgResponse{
-		BaseResponse: newBaseRequest(r, message, code, kvs),
+		BaseResponse: newBaseResponse(r, message, code, kvs),
 	}
 }


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #502 

---

## :construction_worker: Changes

* [chi ](https://github.com/go-chi/chi) + middleware for routing needs
* basic JSON structure for as many things as I could update without demolishing things (package `api` and package `res`)
* update CLI and stuff as much as possible without radical changes

Here's the idea - all responses should be structured like this:

```go
// BaseResponse is the underlying response structure to all responses.
type BaseResponse struct {
	// Basic metadata
	HTTPStatusCode int    `json:"code"`
	RequestID      string `json:"request_id,omitempty"`

	// Message is included in all responses, and is a summary of the server's response
	Message string `json:"message"`

	// Error contains additional context in the event of an error
	Error string `json:"error,omitempty"`

	// Data contains information the server wants to return
	Data interface{} `json:"data,omitempty"`
}
```

`Data` is a json object of some sort. For example, `login` response looks like:

```js
{
   "code":200,
   "request_id":"bobbook/2Mch7LMzhj-000001",
   "message":"session created",
   "data":{
      "token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uX2lkIjoiTEZ4cGVsMTc3R1hMd3d6Y281UjhNU0Z5eDZadWFYa0FQcFJpa25iRzhZTT0iLCJ1c2VyIjoiYm9iaGVhZHhpIiwiYWRtaW4iOmZhbHNlLCJleHBpcnkiOiIyMDE5LTAyLTEyVDA1OjAxOjM2LjgzMTQwNi0wODowMCJ9.0cszidOwITpIU3ZidENTwfnFBdorkkApXXfUkfUDsi0"
   }
}
```

and `totp/enable` looks like:

```js
{
   "code":200,
   "request_id":"bobbook/4NVeCCyrcK-000002",
   "message":"TOTP successfully enabled",
   "data":{
      "totp":{
         "secret":"D3YPABNVY6GBK3EH",
         "backup_codes":[
            "4aac6-44509",
            "a3415-2ccec",
            "5c14b-cbdb5",
            "3376e-0ca9c",
            "487ba-722f7",
            "63f2c-040c1",
            "9b0d6-4b561",
            "64442-157de",
            "497ee-07888",
            "be823-a7aa4"
         ]
      }
   }
}
```

there's also a handy new utility for working with these responses clientside (not used much yet, but will leave for another PR):

```go
var totpResp = &api.TotpResponse{}
api.Unmarshal(resp.Body, api.KV{Key: "totp", Value: totpResp})
fmt.Printf("%+v", totpResp) // { "secret": "...", "backup_codes": [ "...", ... ] }
```

This PR is gonna help out #109, #236, #389 and probably more

## :flashlight: Testing Instructions

run tests

also run testenv and try out all the `inertia [remote]` commands, they'll look ugly but... they shouldnt break (I hope 😋 )