### PR TITLE
chore: write to CNAME after build

### DIFF
--- a/.scripts/build_docs.sh
+++ b/.scripts/build_docs.sh
@@ -66,3 +66,10 @@ bundle install
 echo "[INFO] Building documentation"
 rm -rf docs
 bundle exec middleman build --clean --build-dir=../../docs
+
+# Add CNAME back
+echo "[INFO] Setting CNAME"
+echo "inertia.ubclaunchpad.com" >> ../../docs/CNAME
+
+# Done!
+echo "[INFO] Done!"


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #559 

---

## :construction_worker: Changes

Forcibly write CNAME after doc build. See #559 for details

## :flashlight: Testing Instructions

```
make docs
```

CNAME should still be there after