### PR TITLE
cmd: fix recursive getRemote()

### DIFF
--- a/cmd/remotes/remotes.go
+++ b/cmd/remotes/remotes.go
@@ -128,7 +128,7 @@ Run 'inertia [remote] init' to gather this information.`,
 	inertia.AddCommand(host.Command)
 }
 
-func (root *HostCmd) getRemote() *cfg.Remote { return root.getRemote() }
+func (root *HostCmd) getRemote() *cfg.Remote { return root.client.Remote }
 
 func (root *HostCmd) attachUpCmd() {
 	const (


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #580 

---

## :construction_worker: Changes

A utility function on the host command was calling itself, making things blow up. See #580 for details

## :flashlight: Testing Instructions

```
inertia ${remote_name} init
```
