### PR TITLE
cmd: fix remote management

### DIFF
--- a/cmd/core/utils/output/format.go
+++ b/cmd/core/utils/output/format.go
@@ -53,6 +53,7 @@ func FormatStatus(s *api.DeploymentStatus) string {
 func FormatRemoteDetails(remote cfg.Remote) string {
 	var remoteString string
 	remoteString += fmt.Sprintf("* IP:                   %s\n", remote.IP)
+	remoteString += fmt.Sprintf("* Version:              %s\n", remote.Version)
 	if remote.Daemon != nil {
 		remoteString += fmt.Sprintf("* Daemon.Port:          %s\n", remote.Daemon.Port)
 		remoteString += fmt.Sprintf("* Daemon.Authenticated: %v\n", remote.Daemon.Token != "")
@@ -63,7 +64,7 @@ func FormatRemoteDetails(remote cfg.Remote) string {
 		remoteString += fmt.Sprintf("* SSH.IdentityFile:     %s\n", remote.SSH.IdentityFile)
 	}
 	if remote.Profiles != nil {
-		remoteString += fmt.Sprintf("* Profiles: %v", remote.Profiles)
+		remoteString += fmt.Sprintf("* Profiles:             %v", remote.Profiles)
 	}
 	return remoteString
 }

--- a/cmd/project/profile.go
+++ b/cmd/project/profile.go
@@ -120,7 +120,7 @@ By default, the profile called 'default' will be used.`,
 			if err := local.SaveRemote(r); err != nil {
 				output.Fatal(err)
 			}
-			fmt.Printf("profile '%s' successfully applied to rmeote '%s'", args[0], args[1])
+			fmt.Printf("profile '%s' successfully applied to remote '%s'", args[0], args[1])
 		},
 	}
 	p.AddCommand(apply)

--- a/docs/tip/cli/README.md
+++ b/docs/tip/cli/README.md
@@ -8,4 +8,4 @@ For a more general usage guide, refer to the [Inertia Usage Guide](https://inert
 For documentation regarding the daemon API, refer to the [API Reference](https://inertia.ubclaunchpad.com/api).
 
 * Generated: 2019-Feb-25
-* Version: v0.5.2-22-gf564008
+* Version: v0.5.2-21-g6feabe4

--- a/docs/tip/cli/inertia_remote_upgrade.md
+++ b/docs/tip/cli/inertia_remote_upgrade.md
@@ -13,15 +13,15 @@ inertia remote upgrade [flags]
 ### Examples
 
 ```
-inertia remote upgrade -r dev -r staging
+inertia remote upgrade dev staging
 ```
 
 ### Options
 
 ```
-  -h, --help                  help for upgrade
-  -r, --remotes stringArray   specify which remotes to modify (default: all)
-      --version string        specify Inertia daemon version to set (default "v0.5.2-22-gf564008")
+      --all              upgrade all remotes
+  -h, --help             help for upgrade
+      --version string   specify Inertia daemon version to set (default "v0.5.2-21-g6feabe4")
 ```
 
 ### Options inherited from parent commands

--- a/docs/tip/index.html
+++ b/docs/tip/index.html
@@ -892,8 +892,7 @@ inertia --version <span class="c"># verify installation</span>
 <blockquote>
 <p>To update configuration and daemon to match CLI version:</p>
 </blockquote>
-<pre class="highlight shell tab-shell"><code>inertia config upgrade
-inertia <span class="k">${</span><span class="nv">remote_name</span><span class="k">}</span> upgrade
+<pre class="highlight shell tab-shell"><code>inertia <span class="k">${</span><span class="nv">remote_name</span><span class="k">}</span> upgrade --all
 </code></pre>
 <p>TODO</p>
 <h1 id='advanced-usage'>Advanced Usage</h1>

--- a/docs_src/index.html.md
+++ b/docs_src/index.html.md
@@ -591,8 +591,7 @@ inertia --version # verify installation
 > To update configuration and daemon to match CLI version:
 
 ```shell
-inertia config upgrade
-inertia ${remote_name} upgrade
+inertia ${remote_name} upgrade --all
 ```
 
 TODO


### PR DESCRIPTION
:tickets: **Ticket(s)**: n/a

---

## :construction_worker: Changes

* fixed config command in docs (missed in #587 )
* fix remote upgrade
    * removed `-r`, just use variable args
* fix remote deletion
* you can now `rm` more than one remote at a time

## :flashlight: Testing Instructions

```
make cli
./inertia remote show ... # should now include version
./inertia upgrade --all
./inertia rm ...
```
