### PR TITLE
cmd: prevent command names from being used as remotes

### DIFF
--- a/cmd/core/utils/output/print.go
+++ b/cmd/core/utils/output/print.go
@@ -15,5 +15,6 @@ func Fatal(args ...interface{}) {
 // Fatalf is a wrapper around fmt.Printf that exits with status 1
 func Fatalf(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
+	println()
 	os.Exit(1)
 }

--- a/cmd/remote/remote.go
+++ b/cmd/remote/remote.go
@@ -1,7 +1,6 @@
 package remotecmd
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -85,8 +84,13 @@ Inertia commands.`,
 		Example: "inertia remote add staging --daemon.gen-secret --ip 1.2.3.4",
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			for _, child := range root.Parent().Commands() {
+				if child.Name() == args[0] {
+					output.Fatalf("'%s' is the name of an Inertia command - please choose something else", args[0])
+				}
+			}
 			if _, found := root.config.GetRemote(args[0]); found {
-				output.Fatal(errors.New("remote " + args[0] + " already exists"))
+				output.Fatalf("remote '%s' already exists", args[0])
 			}
 			homeEnvVar, err := local.GetHomePath()
 			if err != nil {

--- a/cmd/remotes/remotes.go
+++ b/cmd/remotes/remotes.go
@@ -32,7 +32,19 @@ func AttachRemotesCmds(root *core.Cmd) {
 	if err != nil {
 		return
 	}
+	var remotes = make(map[string]bool)
 	for _, r := range cfg.Remotes {
+		if _, ok := remotes[r.Name]; ok {
+			output.Fatalf("you have configured multiple remotes named '%s' - please rename one in %s",
+				r.Name, local.InertiaConfigPath())
+		}
+		for _, child := range root.Commands() {
+			if child.Name() == r.Name {
+				output.Fatalf("you have configured a remote named '%s', which is an Inertia command - please rename it in %s",
+					r.Name, local.InertiaConfigPath())
+			}
+		}
+		remotes[r.Name] = true
 		AttachRemoteHostCmd(root, CmdOptions{
 			RemoteCfg:  r,
 			ProjectCfg: project,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,8 +65,10 @@ Global inertia configuration is stored in '%s'.
 	projectcmd.AttachProjectCmd(root)
 	remotecmd.AttachRemoteCmd(root)
 	provisioncmd.AttachProvisionCmd(root)
-	remotescmd.AttachRemotesCmds(root)
 	attachContribPlugins(root)
+
+	// attach configured remotes last
+	remotescmd.AttachRemotesCmds(root)
 
 	return root
 }


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #591

---

## :construction_worker: Changes

Adding a remote first checks if the remote is also a command name

## :flashlight: Testing Instructions

```
❯ ./inertia remote add remote
'remote' is the name of an Inertia command - please choose something else
```
