### PR TITLE
local: use os.ModePerm when writing config files

### DIFF
--- a/local/init.go
+++ b/local/init.go
@@ -10,7 +10,7 @@ import (
 // Init sets up Inertia configuration
 func Init() (*cfg.Inertia, error) {
 	var inertiaPath = InertiaDir()
-	os.MkdirAll(inertiaPath, 0400)
+	os.MkdirAll(inertiaPath, os.ModePerm)
 	var inertia = cfg.NewInertiaConfig()
 	return inertia, Write(InertiaConfigPath(), inertia)
 }

--- a/local/storage.go
+++ b/local/storage.go
@@ -108,7 +108,7 @@ func Write(path string, data interface{}, writers ...io.Writer) error {
 
 		// Overwrite file if file exists
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
-			ioutil.WriteFile(path, []byte(""), 0644)
+			ioutil.WriteFile(path, []byte(""), os.ModePerm)
 		} else if err != nil {
 			return err
 		}


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #600

---

## :construction_worker: Changes

* use `os.ModePerm` instead of `0400` when creating config files

## :flashlight: Testing Instructions

```
inertia init --global
inertia remote ls # should not say something about permissions
```
