### PR TITLE
cmd: handle boolean types in config options

### DIFF
--- a/cfg/util.go
+++ b/cfg/util.go
@@ -3,6 +3,7 @@ package cfg
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -31,10 +32,20 @@ func SetProperty(name string, value string, obj interface{}) error {
 				var fieldPtr = fieldVal.Elem().Addr()
 				return SetProperty(strings.Join(parts[1:], "."), value, fieldPtr.Interface())
 			}
-			if fieldVal.IsValid() && fieldVal.CanSet() && fieldVal.Kind() == reflect.String {
-				// attempt to set string
-				fieldVal.SetString(value)
-				return nil
+			if fieldVal.IsValid() && fieldVal.CanSet() {
+				if fieldVal.Kind() == reflect.String {
+					// attempt to set string
+					fieldVal.SetString(value)
+					return nil
+				}
+
+				if fieldVal.Kind() == reflect.Bool {
+					// attempt to set boolean
+					if _, err := strconv.ParseBool(value); err == nil {
+						fieldVal.SetBool(true)
+						return nil
+					}
+				}
 			}
 		}
 	}

--- a/cfg/util_test.go
+++ b/cfg/util_test.go
@@ -54,6 +54,18 @@ func TestSetProperty(t *testing.T) {
 				}
 				return nil
 			}},
+		{"ok: set boolean",
+			args{"daemon.verify-ssl", "true", &Remote{
+				Daemon: &Daemon{VerifySSL: false},
+			}},
+			false,
+			func(d interface{}) error {
+				var remote = d.(*Remote)
+				if !remote.Daemon.VerifySSL {
+					return fmt.Errorf("value not set (found '%t')", remote.Daemon.VerifySSL)
+				}
+				return nil
+			}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #590

---

## :construction_worker: Changes

Just identify the type of `fieldVal` and in the correct evaluation use `strconv` to validate the input.

The valid values could be ([doc](https://golang.org/pkg/strconv/#ParseBool)):
> 1, t, T, TRUE, true, True, 0, f, F, FALSE

## :flashlight: Testing Instructions

`go test ./cfg` or `make test`
