### PR TITLE
chore: use go1.13 in CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ clone_folder: c:\gopath\src\github.com\ubclaunchpad\inertia
 environment:
   GOPATH: c:\gopath
   DEPTESTBYPASS501: 1
-  GOVERSION: "1.12"
+  GOVERSION: "1.13"
 
 init:
   - git config --global core.autocrlf input
@@ -27,7 +27,7 @@ install:
   - go get -u github.com/golang/dep/cmd/dep
   - dep ensure -v
 
-deploy: "off"
+deploy: false
 
 build_script:
   - go build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - "1.12"
+  - "1.13"
 services:
   - docker
 


### PR DESCRIPTION
:tickets: **Ticket(s)**: for #611 

---

## :construction_worker: Changes

Bump CI/CD to use go1.13

