### PR TITLE
local: use go1.13 UserConfigDir for InertiaDir

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,7 +269,7 @@ $> inertia local init
 $> inertia local status
 ```
 
-The above steps will pull and use a daemon image from Docker Hub based on the version in your `.inertia.toml`.
+The above steps will pull and use a daemon image from Docker Hub based on the version in your remote configuration. The location of the remote configuration file can be can be found using `inertia remote config-path`.
 
 Following these steps, you can run Inertia through deployment:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ $> make install       # installs Inertia build tagged as "test" to gopath
 $> inertia --version  # check what version you have installed
 ```
 
-A build tagged as `test` allows you to use `make testdaemon` for local development. See the next section for more details. Alternatively, you can manually edit `.inertia.toml` to use your desired daemon version - see the [Release Streams](#release-streams) documentation for more details.
+A build tagged as `test` allows you to use `make testdaemon` for local development. See the next section for more details. Alternatively, you can manually edit the remote configuration to use your desired daemon version (see [Setting Up a Test Environment](#setting-up-a-testing-environment)).
 
 Note that if you install Inertia using these commands or any variation of `go install`, you may have to remove the binary using `go clean -i github.com/ubclaunchpad/inertia` to use an Inertia CLI installed using Homebrew. To go back to a `go install`ed version of Inertia, you need to run `brew uninstall inertia`.
 

--- a/cmd/remote/remote.go
+++ b/cmd/remote/remote.go
@@ -31,13 +31,15 @@ func AttachRemoteCmd(inertia *core.Cmd) {
 		Long: `Configures local settings for a remote host - add, remove, and list configured
 Inertia remotes.
 
-Requires Inertia to be set up via 'inertia init'.
+Requires Inertia to be set up via 'inertia init'. To see where the remote
+configuration is stored, run 'inertia remote config-path'.
 
 For example:
-inertia init
-inertia remote add gcloud
-inertia gcloud init        # set up Inertia
-inertia gcloud status      # check on status of Inertia daemon
+
+	inertia init
+	inertia remote add gcloud
+	inertia gcloud init        # set up Inertia
+	inertia gcloud status      # check on status of Inertia daemon
 `,
 		PersistentPreRun: func(*cobra.Command, []string) {
 			// Ensure project initialized, load config
@@ -56,6 +58,7 @@ inertia gcloud status      # check on status of Inertia daemon
 	remote.attachListCmd()
 	remote.attachRemoveCmd()
 	remote.attachUpgradeCmd()
+	remote.attachConfigPathCmd()
 
 	// add to parent
 	inertia.AddCommand(remote.Command)
@@ -333,4 +336,18 @@ func (root *RemoteCmd) attachSetCmd() {
 		},
 	}
 	root.AddCommand(set)
+}
+
+func (root *RemoteCmd) attachConfigPathCmd() {
+	var cfgPath = &cobra.Command{
+		Use:   "config-path",
+		Short: "Output path to remote configuration.",
+		Long: `Outputs where remotes are stored. Note that the configuration directory
+can be set using INERTIA_PATH.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			out.Printf("global configuration directory: '%s'\n", local.InertiaDir())
+			out.Printf("global configuration path:      '%s'\n", local.InertiaConfigPath())
+		},
+	}
+	root.AddCommand(cfgPath)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ func NewInertiaCmd(version, inertiaConfigPath string) *core.Cmd {
 	}
 
 	// persistent flags across all children
-	root.PersistentFlags().StringVar(&root.ProjectConfigPath, "config", "inertia.toml", "specify relative path to Inertia configuration")
+	root.PersistentFlags().StringVar(&root.ProjectConfigPath, "config", "inertia.toml", "specify relative path to Inertia project configuration")
 	root.PersistentFlags().Bool("simple", false, "disable colour and emoji output")
 	// hack in flag parsing - this must be done because we need to initialize the
 	// host commands properly when Cobra first constructs the command tree, which

--- a/local/storage.go
+++ b/local/storage.go
@@ -20,11 +20,11 @@ func InertiaDir() string {
 	if os.Getenv("INERTIA_PATH") != "" {
 		return os.Getenv("INERTIA_PATH")
 	}
-	home, err := os.UserHomeDir()
+	confDir, err := os.UserConfigDir()
 	if err != nil {
-		return "/.inertia"
+		return "/inertia"
 	}
-	return filepath.Join(home, ".inertia")
+	return filepath.Join(confDir, "inertia")
 }
 
 // InertiaConfigPath gets the path to global Inertia configuration

--- a/local/storage.go
+++ b/local/storage.go
@@ -35,7 +35,7 @@ func GetInertiaConfig() (*cfg.Inertia, error) {
 	raw, err := ioutil.ReadFile(InertiaConfigPath())
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, errors.New("config file doesn't exist")
+			return nil, errors.New("global config file doesn't exist - try running 'inertia init --global'")
 		}
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func GetProject(path string) (*cfg.Project, error) {
 	raw, err := ioutil.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, errors.New("config file doesn't exist - try running inertia init")
+			return nil, errors.New("project config file doesn't exist - try running 'inertia init'")
 		}
 		return nil, err
 	}


### PR DESCRIPTION
:tickets: **Ticket(s)**: for #611

---

## :construction_worker: Changes

* use the new [`UserConfigDir`](https://github.com/golang/go/issues/29960) in the standard library to put global Inertia config in
* `inertia remote config-path` to show where stuff is going
* minor update to contributing docs to reflect changes

## :flashlight: Testing Instructions

```
❯ ./inertia init --global
global Inertia configuration intialized at /Users/robertlin/Library/Application Support/inertia/inertia.global
❯ ./inertia remote config-path                                                   
global configuration directory: '/Users/robertlin/Library/Application Support/inertia'
global configuration path:      '/Users/robertlin/Library/Application Support/inertia/inertia.global'
```
