### PR TITLE
config: rename .global to .remotes

### DIFF
--- a/cfg/remotes.go
+++ b/cfg/remotes.go
@@ -4,22 +4,22 @@ import (
 	"github.com/ubclaunchpad/inertia/cfg/internal/identity"
 )
 
-// Inertia denotes global Inertia configuration
-type Inertia struct {
+// Remotes denotes global Inertia configuration
+type Remotes struct {
 	// Remotes tracks globally configured remotes. It is a list instead of a map
 	// to better align with TOML best practices
 	Remotes []*Remote `toml:"remote"`
 }
 
-// NewInertiaConfig instantiates a new Inertia configuration
-func NewInertiaConfig() *Inertia {
-	return &Inertia{
+// NewRemotesConfig instantiates a new Inertia configuration
+func NewRemotesConfig() *Remotes {
+	return &Remotes{
 		Remotes: make([]*Remote, 0),
 	}
 }
 
 // GetRemote retrieves a remote by name
-func (i *Inertia) GetRemote(name string) (*Remote, bool) {
+func (i *Remotes) GetRemote(name string) (*Remote, bool) {
 	if name == "" {
 		return nil, false
 	}
@@ -31,7 +31,7 @@ func (i *Inertia) GetRemote(name string) (*Remote, bool) {
 }
 
 // SetRemote adds or updates a remote to configuration
-func (i *Inertia) SetRemote(remote Remote) {
+func (i *Remotes) SetRemote(remote Remote) {
 	if remote.Name == "" {
 		return
 	}
@@ -44,7 +44,7 @@ func (i *Inertia) SetRemote(remote Remote) {
 }
 
 // RemoveRemote removes remote with given name
-func (i *Inertia) RemoveRemote(name string) bool {
+func (i *Remotes) RemoveRemote(name string) bool {
 	if name == "" {
 		return false
 	}

--- a/cfg/remotes_test.go
+++ b/cfg/remotes_test.go
@@ -22,10 +22,10 @@ var exampleRemote = &Remote{
 }
 
 func TestNewInertiaConfig(t *testing.T) {
-	assert.NotNil(t, NewInertiaConfig())
+	assert.NotNil(t, NewRemotesConfig())
 }
 
-func TestInertia_GetRemote(t *testing.T) {
+func TestRemotes_GetRemote(t *testing.T) {
 	type fields struct {
 		Remotes []*Remote
 	}
@@ -50,7 +50,7 @@ func TestInertia_GetRemote(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var i = &Inertia{
+			var i = &Remotes{
 				Remotes: tt.fields.Remotes,
 			}
 			got, found := i.GetRemote(tt.args.name)
@@ -88,7 +88,7 @@ func TestInertia_SetRemote(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var i = &Inertia{
+			var i = &Remotes{
 				Remotes: tt.fields.Remotes,
 			}
 			i.SetRemote(tt.args.remote)
@@ -124,7 +124,7 @@ func TestInertia_RemoveRemote(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var i = &Inertia{
+			var i = &Remotes{
 				Remotes: tt.fields.Remotes,
 			}
 			assert.Equal(t, tt.want, i.RemoveRemote(tt.args.name))

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -35,10 +35,10 @@ See https://inertia.ubclaunchpad.com/#project-configuration for more details.`,
 		Args:    cobra.RangeArgs(0, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if global, _ := cmd.Flags().GetBool(flagGlobal); global {
-				if _, err := local.Init(); err != nil {
+				if _, err := local.Initialize(); err != nil {
 					out.Fatal(err)
 				}
-				out.Printf("global Inertia configuration intialized at %s", local.InertiaConfigPath())
+				out.Printf("global Inertia configuration intialized in '%s'", local.InertiaDir())
 				return
 			}
 
@@ -46,7 +46,7 @@ See https://inertia.ubclaunchpad.com/#project-configuration for more details.`,
 			var highlight = out.NewColorer(out.CY)
 
 			// Check for global inertia configuration
-			if _, err := local.GetInertiaConfig(); err != nil {
+			if _, err := local.GetRemotes(); err != nil {
 				resp, err := input.Prompt(
 					highlight.Sf(":question: Could not find global inertia configuration in %s (%s) - would you like to initialize it?",
 						local.InertiaDir(), err.Error()))
@@ -54,10 +54,10 @@ See https://inertia.ubclaunchpad.com/#project-configuration for more details.`,
 					out.Fatal(err)
 				}
 				if resp == "y" || resp == "yes" {
-					if _, err := local.Init(); err != nil {
+					if _, err := local.Initialize(); err != nil {
 						out.Fatal(err)
 					}
-					out.Printf("global Inertia configuration intialized at %s\n", local.InertiaConfigPath())
+					out.Printf("global Inertia configuration intialized in '%s'\n", local.InertiaRemotesPath())
 				} else {
 					out.Fatal("aborting: global inertia configuration is required to set up Inertia")
 				}

--- a/cmd/project/profile.go
+++ b/cmd/project/profile.go
@@ -106,7 +106,7 @@ By default, the profile called 'default' will be used.`,
 			if _, ok := p.root.config.GetProfile(args[0]); !ok {
 				out.Fatalf("profile '%s' does not exist", args[0])
 			}
-			cfg, err := local.GetInertiaConfig()
+			cfg, err := local.GetRemotes()
 			if err != nil {
 				out.Fatal(err)
 			}

--- a/cmd/provision/provision.go
+++ b/cmd/provision/provision.go
@@ -20,7 +20,7 @@ import (
 // ProvisionCmd is the parent class for the 'inertia provision' subcommands
 type ProvisionCmd struct {
 	*cobra.Command
-	config  *cfg.Inertia
+	remotes *cfg.Remotes
 	project *cfg.Project
 	cfgPath string
 }
@@ -39,7 +39,7 @@ func AttachProvisionCmd(inertia *core.Cmd) {
 		Long:  `Provisions a new remote host set up for continuous deployment with Inertia.`,
 		PersistentPreRun: func(*cobra.Command, []string) {
 			var err error
-			prov.config, err = local.GetInertiaConfig()
+			prov.remotes, err = local.GetRemotes()
 			if err != nil {
 				out.Fatalf(err.Error())
 			}
@@ -84,8 +84,7 @@ This ensures that your project ports are properly exposed and externally accessi
 `,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var config = root.config
-			if _, found := config.GetRemote(args[0]); found {
+			if _, found := root.remotes.GetRemote(args[0]); found {
 				out.Fatal("remote with name already exists")
 			}
 

--- a/cmd/remotes/remotes.go
+++ b/cmd/remotes/remotes.go
@@ -27,7 +27,7 @@ func AttachRemotesCmds(root *core.Cmd) {
 	if err != nil {
 		return
 	}
-	cfg, err := local.GetInertiaConfig()
+	cfg, err := local.GetRemotes()
 	if err != nil {
 		return
 	}
@@ -35,12 +35,12 @@ func AttachRemotesCmds(root *core.Cmd) {
 	for _, r := range cfg.Remotes {
 		if _, ok := remotes[r.Name]; ok {
 			out.Fatalf("you have configured multiple remotes named '%s' - please rename one in %s",
-				r.Name, local.InertiaConfigPath())
+				r.Name, local.InertiaRemotesPath())
 		}
 		for _, child := range root.Commands() {
 			if child.Name() == r.Name {
 				out.Fatalf("you have configured a remote named '%s', which is an Inertia command - please rename it in %s",
-					r.Name, local.InertiaConfigPath())
+					r.Name, local.InertiaRemotesPath())
 			}
 		}
 		remotes[r.Name] = true

--- a/contrib/inertia-docgen/main.go
+++ b/contrib/inertia-docgen/main.go
@@ -37,7 +37,7 @@ For documentation regarding the daemon API, refer to the [API Reference](https:/
 
 func main() {
 	os.Setenv(out.EnvColorToggle, "false")
-	var root = cmd.NewInertiaCmd(Version, "~/.inertia/inertia.global")
+	var root = cmd.NewInertiaCmd(Version, "~/.inertia")
 	if err := newDocgenCmd(root).Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)

--- a/docs/tip/cli/README.md
+++ b/docs/tip/cli/README.md
@@ -7,5 +7,5 @@ For a more general usage guide, refer to the [Inertia Usage Guide](https://inert
 
 For documentation regarding the daemon API, refer to the [API Reference](https://inertia.ubclaunchpad.com/api).
 
-* Generated: 2019-Mar-15
-* Version: v0.5.2-28-g4d124ef
+* Generated: 2019-Oct-06
+* Version: v0.6.0-preview1-11-gbc4bb8e

--- a/docs/tip/cli/inertia.md
+++ b/docs/tip/cli/inertia.md
@@ -14,7 +14,7 @@ Once you have set up a remote with 'inertia remote add [remote]', use
 'inertia [remote] --help' to see what you can do with your remote. To list
 available remotes, use 'inertia remote ls'.
 
-Global inertia configuration is stored in '~/.inertia/inertia.global'.
+Global inertia configuration is stored in '~/.inertia'.
 
 💻  Repository:    https://github.com/ubclaunchpad/inertia/
 🎫  Issue tracker: https://github.com/ubclaunchpad/inertia/issues
@@ -23,7 +23,7 @@ Global inertia configuration is stored in '~/.inertia/inertia.global'.
 ### Options
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
   -h, --help            help for inertia
       --simple          disable colour and emoji output
 ```

--- a/docs/tip/cli/inertia_${remote_name}.md
+++ b/docs/tip/cli/inertia_${remote_name}.md
@@ -27,7 +27,7 @@ Run 'inertia [remote] init' to gather this information.
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_${remote_name}_down.md
+++ b/docs/tip/cli/inertia_${remote_name}_down.md
@@ -21,7 +21,7 @@ inertia ${remote_name} down [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_env.md
+++ b/docs/tip/cli/inertia_${remote_name}_env.md
@@ -22,7 +22,7 @@ as follows:
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_env_ls.md
+++ b/docs/tip/cli/inertia_${remote_name}_env_ls.md
@@ -20,7 +20,7 @@ inertia ${remote_name} env ls [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_env_rm.md
+++ b/docs/tip/cli/inertia_${remote_name}_env_rm.md
@@ -20,7 +20,7 @@ inertia ${remote_name} env rm [name] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_env_set.md
+++ b/docs/tip/cli/inertia_${remote_name}_env_set.md
@@ -21,7 +21,7 @@ inertia ${remote_name} env set [name] [value] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_init.md
+++ b/docs/tip/cli/inertia_${remote_name}_init.md
@@ -28,7 +28,7 @@ inertia ${remote_name} init [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_logs.md
+++ b/docs/tip/cli/inertia_${remote_name}_logs.md
@@ -24,7 +24,7 @@ inertia ${remote_name} logs [container] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_prune.md
+++ b/docs/tip/cli/inertia_${remote_name}_prune.md
@@ -19,7 +19,7 @@ inertia ${remote_name} prune [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_send.md
+++ b/docs/tip/cli/inertia_${remote_name}_send.md
@@ -21,7 +21,7 @@ inertia ${remote_name} send [filepath] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_ssh.md
+++ b/docs/tip/cli/inertia_${remote_name}_ssh.md
@@ -19,7 +19,7 @@ inertia ${remote_name} ssh [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_status.md
+++ b/docs/tip/cli/inertia_${remote_name}_status.md
@@ -21,7 +21,7 @@ inertia ${remote_name} status [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_token.md
+++ b/docs/tip/cli/inertia_${remote_name}_token.md
@@ -19,7 +19,7 @@ inertia ${remote_name} token [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_uninstall.md
+++ b/docs/tip/cli/inertia_${remote_name}_uninstall.md
@@ -20,7 +20,7 @@ inertia ${remote_name} uninstall [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_up.md
+++ b/docs/tip/cli/inertia_${remote_name}_up.md
@@ -24,7 +24,7 @@ inertia ${remote_name} up [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_upgrade.md
+++ b/docs/tip/cli/inertia_${remote_name}_upgrade.md
@@ -20,7 +20,7 @@ inertia ${remote_name} upgrade [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_user.md
+++ b/docs/tip/cli/inertia_${remote_name}_user.md
@@ -15,7 +15,7 @@ Configure user access to the Inertia Web application.
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_user_add.md
+++ b/docs/tip/cli/inertia_${remote_name}_user_add.md
@@ -25,7 +25,7 @@ inertia ${remote_name} user add [user] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_user_login.md
+++ b/docs/tip/cli/inertia_${remote_name}_user_login.md
@@ -20,7 +20,7 @@ inertia ${remote_name} user login [user] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_user_ls.md
+++ b/docs/tip/cli/inertia_${remote_name}_user_ls.md
@@ -19,7 +19,7 @@ inertia ${remote_name} user ls [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_user_reset.md
+++ b/docs/tip/cli/inertia_${remote_name}_user_reset.md
@@ -21,7 +21,7 @@ inertia ${remote_name} user reset [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_user_rm.md
+++ b/docs/tip/cli/inertia_${remote_name}_user_rm.md
@@ -22,7 +22,7 @@ inertia ${remote_name} user rm [user] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_user_totp.md
+++ b/docs/tip/cli/inertia_${remote_name}_user_totp.md
@@ -15,7 +15,7 @@ Manage 2FA TOTP settings for registered users on your Inertia daemon
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_user_totp_disable.md
+++ b/docs/tip/cli/inertia_${remote_name}_user_totp_disable.md
@@ -19,7 +19,7 @@ inertia ${remote_name} user totp disable [user] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_${remote_name}_user_totp_enable.md
+++ b/docs/tip/cli/inertia_${remote_name}_user_totp_enable.md
@@ -19,7 +19,7 @@ inertia ${remote_name} user totp enable [user] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --debug           enable debug output from Inertia client
   -s, --short           don't stream output from command
       --simple          disable colour and emoji output

--- a/docs/tip/cli/inertia_init.md
+++ b/docs/tip/cli/inertia_init.md
@@ -35,7 +35,7 @@ inertia init my_awesome_project
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_project.md
+++ b/docs/tip/cli/inertia_project.md
@@ -19,7 +19,7 @@ For configuring remote settings, use 'inertia remote'.
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_project_profile.md
+++ b/docs/tip/cli/inertia_project_profile.md
@@ -15,7 +15,7 @@ Manage profile configurations for your project
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_project_profile_apply.md
+++ b/docs/tip/cli/inertia_project_profile_apply.md
@@ -23,7 +23,7 @@ inertia project profile apply [profile] [remote] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_project_profile_configure.md
+++ b/docs/tip/cli/inertia_project_profile_configure.md
@@ -31,7 +31,7 @@ inertia project profile configure my_profile --build.type dockerfile --build.fil
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_project_profile_ls.md
+++ b/docs/tip/cli/inertia_project_profile_ls.md
@@ -21,7 +21,7 @@ inertia project profile ls [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_project_profile_show.md
+++ b/docs/tip/cli/inertia_project_profile_show.md
@@ -20,7 +20,7 @@ inertia project profile show [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_project_reset.md
+++ b/docs/tip/cli/inertia_project_reset.md
@@ -20,7 +20,7 @@ inertia project reset [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_project_set.md
+++ b/docs/tip/cli/inertia_project_set.md
@@ -19,7 +19,7 @@ inertia project set [property] [value] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_provision.md
+++ b/docs/tip/cli/inertia_provision.md
@@ -17,7 +17,7 @@ Provisions a new remote host set up for continuous deployment with Inertia.
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_provision_ec2.md
+++ b/docs/tip/cli/inertia_provision_ec2.md
@@ -34,7 +34,7 @@ inertia provision ec2 [name] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        specify relative path to Inertia configuration (default "inertia.toml")
+      --config string        specify relative path to Inertia project configuration (default "inertia.toml")
   -d, --daemon.port string   daemon port (default "4303")
   -p, --ports stringArray    ports your project uses
       --simple               disable colour and emoji output

--- a/docs/tip/cli/inertia_remote.md
+++ b/docs/tip/cli/inertia_remote.md
@@ -7,13 +7,15 @@ Configure the local settings for a remote host
 Configures local settings for a remote host - add, remove, and list configured
 Inertia remotes.
 
-Requires Inertia to be set up via 'inertia init'.
+Requires Inertia to be set up via 'inertia init'. To see where the remote
+configuration is stored, run 'inertia remote config-path'.
 
 For example:
-inertia init
-inertia remote add gcloud
-inertia gcloud init        # set up Inertia
-inertia gcloud status      # check on status of Inertia daemon
+
+	inertia init
+	inertia remote add gcloud
+	inertia gcloud init        # set up Inertia
+	inertia gcloud status      # check on status of Inertia daemon
 
 
 ### Options
@@ -25,7 +27,7 @@ inertia gcloud status      # check on status of Inertia daemon
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 
@@ -33,6 +35,7 @@ inertia gcloud status      # check on status of Inertia daemon
 
 * [inertia](inertia.md)	 - Effortless, self-hosted continuous deployment for small teams and projects
 * [inertia remote add](inertia_remote_add.md)	 - Add a reference to a remote VPS instance
+* [inertia remote config-path](inertia_remote_config-path.md)	 - Output path to remote configuration.
 * [inertia remote ls](inertia_remote_ls.md)	 - List currently configured remotes
 * [inertia remote rm](inertia_remote_rm.md)	 - Remove a configured remote
 * [inertia remote set](inertia_remote_set.md)	 - Update details about remote

--- a/docs/tip/cli/inertia_remote_add.md
+++ b/docs/tip/cli/inertia_remote_add.md
@@ -33,7 +33,7 @@ inertia remote add staging --daemon.gen-secret --ip 1.2.3.4
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_remote_config-path.md
+++ b/docs/tip/cli/inertia_remote_config-path.md
@@ -1,25 +1,20 @@
-## inertia remote rm
+## inertia remote config-path
 
-Remove a configured remote
+Output path to remote configuration.
 
 ### Synopsis
 
-Remove a remote from Inertia's configuration file.
+Outputs where remotes are stored. Note that the configuration directory
+can be set using INERTIA_PATH.
 
 ```
-inertia remote rm [remote] [flags]
-```
-
-### Examples
-
-```
-inertia remote rm staging
+inertia remote config-path [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for rm
+  -h, --help   help for config-path
 ```
 
 ### Options inherited from parent commands

--- a/docs/tip/cli/inertia_remote_ls.md
+++ b/docs/tip/cli/inertia_remote_ls.md
@@ -20,7 +20,7 @@ inertia remote ls [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_remote_set.md
+++ b/docs/tip/cli/inertia_remote_set.md
@@ -19,7 +19,7 @@ inertia remote set [remote] [property] [value] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_remote_show.md
+++ b/docs/tip/cli/inertia_remote_show.md
@@ -25,7 +25,7 @@ inertia remote show staging
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/cli/inertia_remote_upgrade.md
+++ b/docs/tip/cli/inertia_remote_upgrade.md
@@ -21,13 +21,13 @@ inertia remote upgrade dev staging
 ```
       --all              upgrade all remotes
   -h, --help             help for upgrade
-      --version string   specify Inertia daemon version to set (default "v0.5.2-28-g4d124ef")
+      --version string   specify Inertia daemon version to set (default "v0.6.0-preview1-11-gbc4bb8e")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   specify relative path to Inertia configuration (default "inertia.toml")
+      --config string   specify relative path to Inertia project configuration (default "inertia.toml")
       --simple          disable colour and emoji output
 ```
 

--- a/docs/tip/index.html
+++ b/docs/tip/index.html
@@ -528,7 +528,7 @@ used to access it. Inertia will also need a few ports exposed, namely one for
 the Inertia daemon (port <code>4303</code> by default) and whatever ports you need for your
 deployed project.</p>
 
-<p>Configured remotes are stored globally in <code>~/.inertia/inertia.global</code>.</p>
+<p>Configured remotes are stored globally in <code>~/.inertia/inertia.remotes</code>.</p>
 
 <aside class="notice">
 If you use a non-standard SSH port (i.e. not port <code>22</code>) or want to
@@ -646,7 +646,7 @@ your remote, and spin up the Inertia daemon!</p>
 inertia remote show <span class="k">${</span><span class="nv">remote_name</span><span class="k">}</span>
 </code></pre>
 <blockquote>
-<p>An example <code>~/.inertia/inertia.global</code>:</p>
+<p>An example <code>~/.inertia/inertia.remotes</code>:</p>
 </blockquote>
 <pre class="highlight toml tab-toml"><code><span class="c"># ... other stuff</span>
 
@@ -682,7 +682,7 @@ to <code>me</code> and print out the new settings:</p>
 inertia remote show my_remote
 </code></pre>
 <p>Once you&#39;ve added a remote, remote-specific settings are available in
-<code>~/.inertia/inertia.global</code>.</p>
+<code>~/.inertia/inertia.remotes</code>.</p>
 
 <aside class="notice">
 For the most part, unless you filled in something incorrectly while adding a

--- a/docs_src/index.html.md
+++ b/docs_src/index.html.md
@@ -212,7 +212,7 @@ used to access it. Inertia will also need a few ports exposed, namely one for
 the Inertia daemon (port `4303` by default) and whatever ports you need for your
 deployed project.
 
-Configured remotes are stored globally in `~/.inertia/inertia.global`.
+Configured remotes are stored globally in `~/.inertia/inertia.remotes`.
 
 <aside class="notice">
 If you use a non-standard SSH port (i.e. not port <code>22</code>) or want to
@@ -334,7 +334,7 @@ inertia remote ls
 inertia remote show ${remote_name}
 ```
 
-> An example `~/.inertia/inertia.global`:
+> An example `~/.inertia/inertia.remotes`:
 
 ```toml
 # ... other stuff
@@ -374,7 +374,7 @@ inertia remote show my_remote
 ```
 
 Once you've added a remote, remote-specific settings are available in
-`~/.inertia/inertia.global`.
+`~/.inertia/inertia.remotes`.
 
 <aside class="notice">
 For the most part, unless you filled in something incorrectly while adding a

--- a/local/init.go
+++ b/local/init.go
@@ -7,12 +7,12 @@ import (
 	"github.com/ubclaunchpad/inertia/cfg"
 )
 
-// Init sets up Inertia configuration
-func Init() (*cfg.Inertia, error) {
+// Initialize sets up Inertia configuration
+func Initialize() (*cfg.Remotes, error) {
 	var inertiaPath = InertiaDir()
 	os.MkdirAll(inertiaPath, os.ModePerm)
-	var inertia = cfg.NewInertiaConfig()
-	return inertia, Write(InertiaConfigPath(), inertia)
+	var remotes = cfg.NewRemotesConfig()
+	return remotes, Write(InertiaRemotesPath(), remotes)
 }
 
 // InitProject creates the inertia config file and returns an error if Inertia

--- a/local/storage.go
+++ b/local/storage.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ubclaunchpad/inertia/cfg"
 )
 
-const inertiaGlobalName = "inertia.global"
+const inertiaRemotesFile = "inertia.remotes"
 
 // InertiaDir gets the path to the directory where global Inertia configuration
 // is stored
@@ -27,12 +27,12 @@ func InertiaDir() string {
 	return filepath.Join(confDir, "inertia")
 }
 
-// InertiaConfigPath gets the path to global Inertia configuration
-func InertiaConfigPath() string { return filepath.Join(InertiaDir(), inertiaGlobalName) }
+// InertiaRemotesPath gets the path to global Inertia configuration
+func InertiaRemotesPath() string { return filepath.Join(InertiaDir(), inertiaRemotesFile) }
 
-// GetInertiaConfig retrieves global Inertia configuration
-func GetInertiaConfig() (*cfg.Inertia, error) {
-	raw, err := ioutil.ReadFile(InertiaConfigPath())
+// GetRemotes retrieves global Inertia remotes configuration
+func GetRemotes() (*cfg.Remotes, error) {
+	raw, err := ioutil.ReadFile(InertiaRemotesPath())
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, errors.New("global config file doesn't exist - try running 'inertia init --global'")
@@ -40,34 +40,34 @@ func GetInertiaConfig() (*cfg.Inertia, error) {
 		return nil, err
 	}
 
-	var inertia cfg.Inertia
-	if err = toml.Unmarshal(raw, &inertia); err != nil {
+	var remotes cfg.Remotes
+	if err = toml.Unmarshal(raw, &remotes); err != nil {
 		return nil, err
 	}
-	return &inertia, nil
+	return &remotes, nil
 }
 
 // SaveRemote adds or updates the given remote in the global Inertia configuration
 // file.
 func SaveRemote(remote *cfg.Remote) error {
-	inertia, err := GetInertiaConfig()
+	remotes, err := GetRemotes()
 	if err != nil {
 		return err
 	}
-	inertia.SetRemote(*remote)
-	return Write(InertiaConfigPath(), inertia)
+	remotes.SetRemote(*remote)
+	return Write(InertiaRemotesPath(), remotes)
 }
 
 // RemoveRemote deletes the named remote from the global Inertia configuration file.
 func RemoveRemote(name string) error {
-	inertia, err := GetInertiaConfig()
+	remotes, err := GetRemotes()
 	if err != nil {
 		return err
 	}
-	if !inertia.RemoveRemote(name) {
+	if !remotes.RemoveRemote(name) {
 		return fmt.Errorf("failed to remove remote '%s'", name)
 	}
-	return Write(InertiaConfigPath(), inertia)
+	return Write(InertiaRemotesPath(), remotes)
 }
 
 // GetProject retrieves the Inertia project configuration at the given path

--- a/local/storage_test.go
+++ b/local/storage_test.go
@@ -23,7 +23,7 @@ func TestWrite(t *testing.T) {
 		wantErr bool
 	}{
 		{"nothing to write to", args{"", nil, nil}, true},
-		{"ok: write to path", args{"./test-config.toml", &cfg.Inertia{
+		{"ok: write to path", args{"./test-config.toml", &cfg.Remotes{
 			Remotes: []*cfg.Remote{
 				{
 					Name: "dev",
@@ -72,7 +72,7 @@ func TestWrite(t *testing.T) {
 				},
 			},
 		}, nil}, false},
-		{"ok: write to writers", args{"", &cfg.Inertia{
+		{"ok: write to writers", args{"", &cfg.Remotes{
 			Remotes: make([]*cfg.Remote, 0),
 		}, []io.Writer{os.Stdout}}, false},
 	}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 var Version string
 
 func main() {
-	if err := cmd.NewInertiaCmd(Version, local.InertiaConfigPath()).Execute(); err != nil {
+	if err := cmd.NewInertiaCmd(Version, local.InertiaDir()).Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}


### PR DESCRIPTION
:tickets: **Ticket(s)**: n/a

---

## :construction_worker: Changes

Renames references of `inertia.global` to `inertia.remotes`. Any additional configuration should probably go elsewhere, and hopefully this makes it a bit less confusing for me

Also rebuilt the `/tip` documentation

## :flashlight: Testing Instructions

n/a
