### PR TITLE
ci: only run Publish(release) on 'published' event, silence bootstrap test log

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,7 +2,7 @@ name: Publish (release)
 
 on:
   release:
-    types: [ published, prereleased ]
+    types: [ published ]
 
 jobs:
   daemon:

--- a/client/bootstrap/bootstrap_test.go
+++ b/client/bootstrap/bootstrap_test.go
@@ -51,6 +51,5 @@ func TestBootstrap_Integration(t *testing.T) {
 	// Check if daemon is online following bootstrap
 	status, err := c.Status(context.Background())
 	require.NoError(t, err, "status check of bootstrapped daemon failed")
-	t.Logf("daemon status: %+v", status)
 	assert.Equal(t, "test", status.InertiaVersion)
 }


### PR DESCRIPTION
:tickets: **Ticket(s)**: follow-up to #628 

---

## :construction_worker: Changes

It seems that the new `Publish (release)` workflow triggers twice for pre-releases - this PR amends that I think

![image](https://user-images.githubusercontent.com/23356519/67165137-40a74b80-f336-11e9-9eba-33aec4e1737c.png)


## :flashlight: Testing Instructions

I'll cut another release later
