### PR TITLE
daemon: log history update as non-critical failure

### DIFF
--- a/daemon/inertiad/daemon/up.go
+++ b/daemon/inertiad/daemon/up.go
@@ -99,9 +99,8 @@ func (s *Server) upHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update container management history following a successful build and deployment
-	err = s.deployment.UpdateContainerHistory(s.docker)
-	if err != nil {
-		stream.Error(res.ErrInternalServer("failed to update container history following build", err))
+	if err = s.deployment.UpdateContainerHistory(s.docker); err != nil {
+		stream.Println("warning: failed to update container history:", err)
 	}
 
 	stream.Success(res.Msg("Project startup initiated!", http.StatusCreated))

--- a/daemon/inertiad/log/streamer.go
+++ b/daemon/inertiad/log/streamer.go
@@ -68,8 +68,8 @@ func (s *Streamer) GetSocketWriter() (io.Writer, error) {
 }
 
 // Println prints to logger's standard writer
-func (s *Streamer) Println(a interface{}) {
-	fmt.Fprintln(s.Writer, a)
+func (s *Streamer) Println(a ...interface{}) {
+	fmt.Fprintln(s.Writer, a...)
 }
 
 // Error directs message and status to http.Error when appropriate


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #626

---

## :construction_worker: Changes

Make container update failure a non-critical error to avoid failing a build