### PR TITLE
daemon(auth): only drop non-master users on reset

### DIFF
--- a/daemon/inertiad/auth/users_test.go
+++ b/daemon/inertiad/auth/users_test.go
@@ -59,6 +59,12 @@ func TestAllUserManagementOperations(t *testing.T) {
 
 	err = manager.HasUser("bobheadxi")
 	assert.Equal(t, errUserNotFound, err)
+
+	// reset should not remove master key
+	err = manager.Reset()
+	assert.NoError(t, err)
+	err = manager.HasUser(masterKey)
+	assert.NoError(t, err)
 }
 
 func TestIsAdmin(t *testing.T) {


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #550

---

## :construction_worker: Changes

* Fixes `inertia [remote] users reset` deleting the "sudo" `master` user

