### PR TITLE
docs: add annotation layer on usage site

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -7,5 +7,5 @@ For a more general usage guide, refer to the [Inertia Usage Guide](https://inert
 
 For documentation regarding the daemon API, refer to the [API Reference](https://inertia.ubclaunchpad.com/api).
 
-* Generated: 2020-Mar-19
+* Generated: 2020-Mar-30
 * Version: v0.6.0

--- a/docs/index.html
+++ b/docs/index.html
@@ -328,6 +328,8 @@
 <a href="https://cloud.docker.com/u/ubclaunchpad/repository/docker/ubclaunchpad/inertia/general"><img src="https://img.shields.io/docker/pulls/ubclaunchpad/inertia.svg?colorB=0db7ed" alt="Inertia" /></a>
 <a href="https://github.com/ubclaunchpad/inertia"><img src="https://img.shields.io/github/stars/ubclaunchpad/inertia.svg?style=social" alt="Inertia" /></a></p>
 
+<script src="https://hypothes.is/embed.js" async></script>
+
 <p><br /></p>
 
 <blockquote>

--- a/docs_src/index.html.md
+++ b/docs_src/index.html.md
@@ -23,6 +23,8 @@ search: false
 [![](https://img.shields.io/docker/pulls/ubclaunchpad/inertia.svg?colorB=0db7ed)](https://cloud.docker.com/u/ubclaunchpad/repository/docker/ubclaunchpad/inertia/general)
 [![](https://img.shields.io/github/stars/ubclaunchpad/inertia.svg?style=social)](https://github.com/ubclaunchpad/inertia)
 
+<script src="https://hypothes.is/embed.js" async></script>
+
 <br />
 
 > **Main Features**


### PR DESCRIPTION
:tickets: **Ticket(s)**: n/a

---

## :construction_worker: Changes

Adds annotation layer via https://hypothes.is/ because... why not I guess?

<img width="1405" alt="image" src="https://user-images.githubusercontent.com/23356519/77952503-9f2b0b00-7280-11ea-9097-5fdca9720ccb.png">

/cc @srijonsaha
