### PR TITLE
chore: publish to github container registry as well

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,7 @@ test
 # Non-daemon source code
 client
 *_test.go
+contrib/npm
 
 # Dependencies
 bin

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -9,7 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Build and publish daemon:latest
+    - name: Build daemon
+      run: make daemon-release RELEASE=latest
+
+    - name: Publish to Docker Hub
       run: |
         docker login -u ${{ secrets.docker_user }} -p ${{ secrets.docker_key }}
-        make daemon-release RELEASE=latest
+        docker push ubclaunchpad/inertia:latest
+    - name: Publish to GitHub Container Registry
+      run: |
+        echo ${{ secrets.GH_PACKAGES_TOKEN }} | docker login ghcr.io --username $GITHUB_ACTOR --password-stdin
+        docker tag ubclaunchpad/inertia:latest ghcr.io/ubclaunchpad/inertia:latest
+        docker push ghcr.io/ubclaunchpad/inertia:latest

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,10 +11,20 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-go@v1
       with: { go-version: '1.14' }
-    - name: Build release and publish daemon
+    - name: Build release
       run: |
         docker login -u ${{ secrets.docker_user }} -p ${{ secrets.docker_key }}
-        bash .scripts/release.sh
+        RELEASE=$(git describe --tags) bash .scripts/release.sh
+
+    - name: Publish to Docker Hub
+      run: |
+        docker login -u ${{ secrets.docker_user }} -p ${{ secrets.docker_key }}
+        docker push ubclaunchpad/inertia:$(git describe --tags)
+    - name: Publish to GitHub Container Registry
+      run: |
+        echo ${{ secrets.GH_PACKAGES_TOKEN }} | docker login ghcr.io --username $GITHUB_ACTOR --password-stdin
+        docker tag ubclaunchpad/inertia:$(git describe --tags) ghcr.io/ubclaunchpad/inertia:$(git describe --tags)
+        docker push ghcr.io/ubclaunchpad/inertia:$(git describe --tags)
     - name: Publish CLI
       uses: softprops/action-gh-release@v1
       with:

--- a/.scripts/release.sh
+++ b/.scripts/release.sh
@@ -2,7 +2,6 @@
 
 # Specify platforms and release version
 PLATFORMS="linux/amd64 linux/386 darwin/amd64 windows/amd64 windows/386"
-RELEASE=$(git describe --tags)
 echo "Building release $RELEASE"
 
 # Build, tag and push Inertia Docker image

--- a/Makefile
+++ b/Makefile
@@ -219,12 +219,11 @@ testenv-clean:
 install-tagged:
 	go install -ldflags "-X $(CLI_VERSION_VAR)=$(TAG)"
 
-## daemon-release: build the daemon and push it to the UBC Launch Pad Docker Hub
+## daemon-release: build the daemon as ubclaunchpad/inertia:RELEASE
 .PHONY: daemon-release
 daemon-release:
 	docker build --build-arg INERTIA_VERSION=$(RELEASE) \
 		-t ubclaunchpad/inertia:$(RELEASE) .
-	docker push ubclaunchpad/inertia:$(RELEASE)
 
 ## cli-release: cross-compile Inertia CLI binaries for distribution
 .PHONY: cli-release


### PR DESCRIPTION
:tickets: **Ticket(s)**: n/a

---

## :construction_worker: Changes

Adds a publish step for GitHub Container Registry as a fallback (since Docker Hub limits are getting reduced)

not sure if we should migrate wholesale yet, but oh well

## :flashlight: Testing Instructions

n/a
