### PR TITLE
chore: target all packages when running integration tests

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -102,7 +102,7 @@ jobs:
       if: ${{ ! matrix.pull_image }}
       run: make testdaemon-scp
     - name: Run bootstrap test
-      run: go test ./client/bootstrap -v -run 'TestBootstrap_Integration' -coverprofile=coverage.txt -ldflags "-X github.com/ubclaunchpad/inertia/cmd.Version=test"
+      run: go test ./... -v -run 'TestBootstrap_Integration' -coverprofile=coverage.txt -ldflags "-X github.com/ubclaunchpad/inertia/cmd.Version=test"
       env:
         INTEGRATION_PULL_IMAGE: ${{ matrix.pull_image }}
     - name: Upload code coverage


### PR DESCRIPTION
:tickets: **Ticket(s)**: n/a

---

## :construction_worker: Changes

This was changed in #692, but seems to mess up our coverage records since the results do not get merged correctly with the unit test results by Codecov.

## :flashlight: Testing Instructions

Explain how to test your changes, if applicable.
