### PR TITLE
client: enforce a minimum daemon version

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -17,7 +17,7 @@ import (
 
 func main() {
 	// set up a client to your remote
-	var inertia = client.NewClient(
+	inertia, _ := client.NewClient(
 		&cfg.Remote{
 			Version: "v0.6.0",
 			Name:    "gcloud",

--- a/client/bootstrap/bootstrap_test.go
+++ b/client/bootstrap/bootstrap_test.go
@@ -30,11 +30,12 @@ func newIntegrationClient() *client.Client {
 			WebHookSecret: "sekret",
 		},
 	}
-	return client.NewClient(remote, client.Options{
+	c, _ := client.NewClient(remote, client.Options{
 		SSH:   runner.SSHOptions{},
 		Out:   os.Stdout,
 		Debug: true,
 	})
+	return c
 }
 
 func TestBootstrap_Integration(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -62,12 +62,32 @@ func newMockClient(t *testing.T, ts *httptest.Server) *Client {
 }
 
 func TestNewClient(t *testing.T) {
-	var c = NewClient(&cfg.Remote{}, Options{})
+	c, err := NewClient(&cfg.Remote{}, Options{})
+	assert.NoError(t, err)
 	assert.NotNil(t, c)
 	c.WithDebug(false)
 	assert.False(t, c.debug)
 	c.WithWriter(os.Stdout)
 	assert.Equal(t, os.Stdout, c.out)
+
+	t.Run("with supported special version strings", func(t *testing.T) {
+		c, err := NewClient(&cfg.Remote{Version: "test"}, Options{})
+		assert.NoError(t, err)
+		assert.NotNil(t, c)
+		c2, err := NewClient(&cfg.Remote{Version: "latest"}, Options{})
+		assert.NoError(t, err)
+		assert.NotNil(t, c2)
+	})
+
+	t.Run("with bad version", func(t *testing.T) {
+		_, err := NewClient(&cfg.Remote{Version: "asdf"}, Options{})
+		assert.Error(t, err)
+	})
+
+	t.Run("with unsupported version", func(t *testing.T) {
+		_, err := NewClient(&cfg.Remote{Version: "v0.6.1"}, Options{})
+		assert.Error(t, err)
+	})
 }
 
 func TestClient_Up(t *testing.T) {

--- a/cmd/provision/provision.go
+++ b/cmd/provision/provision.go
@@ -194,9 +194,12 @@ This ensures that your project ports are properly exposed and externally accessi
 			local.SaveRemote(remote)
 
 			// Create inertia client
-			var inertia = client.NewClient(remote, client.Options{
+			inertia, err := client.NewClient(remote, client.Options{
 				SSH: runner.SSHOptions{KeyPassphrase: os.Getenv(local.EnvSSHPassphrase)},
 			})
+			if err != nil {
+				out.Fatal((err))
+			}
 
 			// Bootstrap remote
 			out.Println(highlight.Sf("Initializing Inertia daemon at %s...", inertia.Remote.IP))

--- a/cmd/remote/remote.go
+++ b/cmd/remote/remote.go
@@ -258,9 +258,11 @@ func (root *RemoteCmd) attachLoginCmd() {
 			}
 
 			// set up client
-			var c = client.
-				NewClient(remoteCfg, client.Options{Out: os.Stdout}).
-				GetUserClient()
+			c, err := client.NewClient(remoteCfg, client.Options{Out: os.Stdout})
+			if err != nil {
+				out.Fatal(err.Error())
+			}
+			users := c.GetUserClient()
 			ctx, cancel := context.WithCancel(context.Background())
 			input.CatchSigterm(cancel)
 
@@ -271,7 +273,7 @@ func (root *RemoteCmd) attachLoginCmd() {
 				Password: string(pwBytes),
 				TOTP:     totp,
 			}
-			token, err := c.Authenticate(ctx, req)
+			token, err := users.Authenticate(ctx, req)
 			if err != nil && err != client.ErrNeedTotp {
 				out.Fatal(err)
 			}
@@ -285,7 +287,7 @@ func (root *RemoteCmd) attachLoginCmd() {
 				}
 				// retry with TOTP
 				req.TOTP = string(totpBytes)
-				token, err = c.Authenticate(ctx, req)
+				token, err = users.Authenticate(ctx, req)
 				if err != nil {
 					out.Fatal(err)
 				}

--- a/cmd/remotes/remotes.go
+++ b/cmd/remotes/remotes.go
@@ -105,15 +105,19 @@ func AttachRemoteHostCmd(
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
 	input.CatchSigterm(cancel)
+	c, err := client.NewClient(opts.RemoteCfg, client.Options{
+		SSH: runner.SSHOptions{
+			KeyPassphrase: os.Getenv(local.EnvSSHPassphrase),
+		},
+		Out: os.Stdout,
+	})
+	if err != nil {
+		out.Fatalf("error loading remote %s: %v", opts.RemoteCfg.Name, err)
+	}
 	var host = &HostCmd{
 		project: opts.ProjectCfg,
-		client: client.NewClient(opts.RemoteCfg, client.Options{
-			SSH: runner.SSHOptions{
-				KeyPassphrase: os.Getenv(local.EnvSSHPassphrase),
-			},
-			Out: os.Stdout,
-		}),
-		ctx: ctx,
+		client:  c,
+		ctx:     ctx,
 	}
 	host.Command = &cobra.Command{
 		Use: opts.RemoteCfg.Name + " [command]",


### PR DESCRIPTION
Since the switch to the new container registry (#692), the bootstrap script will no longer correctly work with pre-0.6.2 images. This change adds a check that requires newer images in remote configuration.

For context, we published an `v0.6.2` image: https://github.com/orgs/ubclaunchpad/packages/container/inertiad/93246